### PR TITLE
Add XP Control Panel, Search, and Run utilities

### DIFF
--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -8,6 +8,35 @@ import * as idb from 'idb-keyval';
 import * as finder from './finder';
 import {Buffer} from 'buffer';
 
+export function search_fs(query){
+    if(utils.is_empty(query)) return [];
+    query = query.toLowerCase();
+    let data = get(hardDrive);
+    return Object.values(data).filter(item => item?.name?.toLowerCase().includes(query));
+}
+
+export function run_command(command){
+    if(utils.is_empty(command)) return;
+    let id = finder.to_id(command) || finder.to_id_nocase(command);
+    if(id){
+        queueProgram.set({path: './programs/my_computer.svelte', fs_item: {id}});
+        return;
+    }
+    if(/^https?:\/\//i.test(command)){
+        queueProgram.set({path: './programs/internet_explorer.svelte', fs_item: {url: command}});
+        return;
+    }
+    let apps = {
+        'notepad': './programs/notepad.svelte',
+        'mspaint': './programs/paint.svelte',
+        'control panel': './programs/control_panel.svelte'
+    };
+    let lower = command.toLowerCase();
+    if(apps[lower]){
+        queueProgram.set({path: apps[lower]});
+    }
+}
+
 export function copy(){
     clipboard_op.set('copy');
     clipboard.set(get(selectingItems));

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -16,3 +16,6 @@ export let hardDrive = writable(null);
 export let clipboard = writable([]);
 export let clipboard_op = writable('copy');
 export let queueCommand = writable(null);
+export let searchResults = writable([]);
+export let runHistory = writable([]);
+

--- a/src/routes/xp/programs/control_panel.svelte
+++ b/src/routes/xp/programs/control_panel.svelte
@@ -1,0 +1,45 @@
+<script>
+    import Window from '../../../lib/components/xp/Window.svelte';
+    import { runningPrograms, queueProgram } from '../../../lib/store';
+
+    export let id;
+    export let window;
+    export let self;
+    export let exec_path;
+
+    export function destroy(){
+        runningPrograms.update(programs => programs.filter(p => p != self));
+        self.$destroy();
+    }
+
+    export let options = {
+        title: 'Control Panel',
+        width: 600,
+        height: 400,
+        icon: '/images/xp/icons/ControlPanel.png',
+        id,
+        exec_path
+    };
+
+    let items = [
+        {name:'Display', icon:'/images/xp/icons/DisplayProperties.png', path:'./programs/display_properties.svelte'},
+        {name:'Add or Remove Programs', icon:'/images/xp/icons/Programs.png', path:'./programs/app_installer.svelte'},
+        {name:'Volume', icon:'/images/xp/icons/Volume.png', path:'./programs/volume_adjust.svelte'}
+    ];
+
+    function open(item){
+        queueProgram.set({path:item.path, ...(item.fs_item?{fs_item:item.fs_item}:{})});
+    }
+</script>
+
+<Window bind:this={window} on_click_close={destroy} options={options}>
+    <div slot="content" class="p-4 grid grid-cols-3 gap-4 text-center select-none">
+        {#each items as item}
+            <div class="flex flex-col items-center cursor-pointer" on:dblclick={() => open(item)}>
+                <img src={item.icon} class="w-12 h-12 mb-2" alt={item.name} />
+                <span class="text-xs">{item.name}</span>
+            </div>
+        {/each}
+    </div>
+</Window>
+

--- a/src/routes/xp/programs/run_dialog.svelte
+++ b/src/routes/xp/programs/run_dialog.svelte
@@ -1,0 +1,49 @@
+<script>
+    import Window from '../../../lib/components/xp/Window.svelte';
+    import { runningPrograms, runHistory } from '../../../lib/store';
+    import * as fs from '../../../lib/fs';
+
+    export let id;
+    export let window;
+    export let self;
+    export let exec_path;
+
+    export function destroy(){
+        runningPrograms.update(programs => programs.filter(p => p != self));
+        self.$destroy();
+    }
+
+    export let options = {
+        title: 'Run',
+        width: 400,
+        height: 150,
+        icon: '/images/xp/icons/Run.png',
+        id,
+        exec_path,
+        resizable: false
+    };
+
+    let command = '';
+
+    function run(){
+        fs.run_command(command);
+        runHistory.update(h => [command, ...h.filter(c => c !== command)].slice(0,10));
+        destroy();
+    }
+
+    function on_key(e){
+        if(e.key === 'Enter') run();
+    }
+</script>
+
+<Window bind:this={window} on_click_close={destroy} options={options}>
+    <div slot="content" class="p-4 text-sm space-y-2">
+        <p>Type the name of a program, folder, document, or Internet resource, and Windows will open it for you.</p>
+        <input bind:value={command} class="border w-full p-1" on:keydown={on_key} autofocus />
+        <div class="flex justify-end space-x-2 mt-2">
+            <button class="px-4 py-1 border" on:click={run}>OK</button>
+            <button class="px-4 py-1 border" on:click={destroy}>Cancel</button>
+        </div>
+    </div>
+</Window>
+

--- a/src/routes/xp/programs/search.svelte
+++ b/src/routes/xp/programs/search.svelte
@@ -1,0 +1,57 @@
+<script>
+    import Window from '../../../lib/components/xp/Window.svelte';
+    import { runningPrograms, queueProgram } from '../../../lib/store';
+    import * as fs from '../../../lib/fs';
+
+    export let id;
+    export let window;
+    export let self;
+    export let exec_path;
+
+    export function destroy(){
+        runningPrograms.update(programs => programs.filter(p => p != self));
+        self.$destroy();
+    }
+
+    export let options = {
+        title: 'Search',
+        width: 500,
+        height: 400,
+        icon: '/images/xp/icons/Search.png',
+        id,
+        exec_path
+    };
+
+    let query = '';
+    let results = [];
+
+    function do_search(){
+        results = fs.search_fs(query);
+    }
+
+    function open(item){
+        if(item.type === 'file'){
+            queueProgram.set({path:'./programs/notepad.svelte', fs_item:item});
+        } else {
+            queueProgram.set({path:'./programs/my_computer.svelte', fs_item:item});
+        }
+    }
+</script>
+
+<Window bind:this={window} on_click_close={destroy} options={options}>
+    <div slot="content" class="p-4 text-sm h-full flex flex-col">
+        <input bind:value={query} class="border p-1 mb-2" placeholder="Search" on:keydown={(e)=>e.key==='Enter' && do_search()} />
+        <div class="overflow-auto flex-1">
+            {#each results as item}
+                <div class="flex items-center space-x-2 cursor-pointer hover:bg-blue-500 hover:text-white p-1" on:dblclick={() => open(item)}>
+                    <img src={item.icon || (item.type==='file' ? '/images/xp/icons/TXT.png' : '/images/xp/icons/FolderClosed.png')} class="w-4 h-4" alt="" />
+                    <span>{item.name}</span>
+                </div>
+            {/each}
+            {#if results.length === 0}
+                <p class="text-center text-gray-500">No results</p>
+            {/if}
+        </div>
+    </div>
+</Window>
+

--- a/src/routes/xp/start_menu.svelte
+++ b/src/routes/xp/start_menu.svelte
@@ -82,7 +82,7 @@
         {
             name: 'Control Panel',
             icon: '/images/xp/icons/ControlPanel.png',
-            path: ''
+            path: './programs/control_panel.svelte'
         },
         {
             name: 'Display Properties',
@@ -104,12 +104,12 @@
         {
             name: 'Search',
             icon: '/images/xp/icons/Search.png',
-            path: ''
+            path: './programs/search.svelte'
         },
         {
             name: 'Run...',
             icon: '/images/xp/icons/Run.png',
-            path: ''
+            path: './programs/run_dialog.svelte'
         }
     ]
 


### PR DESCRIPTION
## Summary
- wire Start menu items for Control Panel, Search, and Run to new program routes
- implement Control Panel window with quick links to system tools
- add Search and Run dialogs with supporting store/actions for file lookup and command execution

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688f3bf962508329840d1d9e15887761