### PR TITLE
feat: add xp tray icons

### DIFF
--- a/src/lib/components/xp/ContextMenu.svelte
+++ b/src/lib/components/xp/ContextMenu.svelte
@@ -39,6 +39,15 @@
         } else if(type == 'RecycleBin'){
             menu_obj = (await import('./context_menu/RecycleBin')).make({type, originator});
 
+        } else if(type == 'TrayNetwork'){
+            menu_obj = (await import('./context_menu/CMTrayNetwork')).make({type, originator});
+
+        } else if(type == 'TraySafelyRemove'){
+            menu_obj = (await import('./context_menu/CMTraySafelyRemove')).make({type, originator});
+
+        } else if(type == 'TrayWindowsUpdate'){
+            menu_obj = (await import('./context_menu/CMTrayWindowsUpdate')).make({type, originator});
+
         } else {
             console.log('unknown context menu type')
         }

--- a/src/lib/components/xp/TrayIcon.svelte
+++ b/src/lib/components/xp/TrayIcon.svelte
@@ -8,6 +8,10 @@
         console.log('on click')
     }
 
+    export let on_contextmenu = (e) => {
+        // optional right click handler
+    }
+
     function on_mouseenter(e){
         if(tooltip_message == null) return;
         let position = {left: e.x, top: e.y - 40};
@@ -24,6 +28,8 @@
 
 </script>
 
-<div class="mr-1 w-4 h-4 bg-no-repeat bg-contain" style:background-image="url({icon})" 
-    on:click={on_click} use:tooltip tooltip="{tooltip_message}">
+<div class="mr-1 w-4 h-4 bg-no-repeat bg-contain" style:background-image="url({icon})"
+    on:click={on_click}
+    on:contextmenu={on_contextmenu}
+    use:tooltip tooltip="{tooltip_message}">
 </div>

--- a/src/lib/components/xp/context_menu/CMTrayNetwork.js
+++ b/src/lib/components/xp/context_menu/CMTrayNetwork.js
@@ -1,0 +1,23 @@
+import { queueProgram } from '../../../store';
+
+export let make = ({type, originator}) => {
+    return {
+        required_width: 200,
+        required_height: 27 + 20,
+        menu: [
+            [
+                {
+                    name: 'Open Network Connections',
+                    font: 'bold',
+                    action: () => {
+                        queueProgram.set({
+                            name: 'Network Connections',
+                            icon: '/images/xp/icons/ConnectionStatus.png',
+                            path: './programs/network_status.svelte'
+                        })
+                    }
+                }
+            ]
+        ]
+    }
+}

--- a/src/lib/components/xp/context_menu/CMTraySafelyRemove.js
+++ b/src/lib/components/xp/context_menu/CMTraySafelyRemove.js
@@ -1,0 +1,23 @@
+import { queueProgram } from '../../../store';
+
+export let make = ({type, originator}) => {
+    return {
+        required_width: 200,
+        required_height: 27 + 20,
+        menu: [
+            [
+                {
+                    name: 'Safely Remove Hardware',
+                    font: 'bold',
+                    action: () => {
+                        queueProgram.set({
+                            name: 'Safely Remove Hardware',
+                            icon: '/images/xp/icons/SafelyRemoveHardware.png',
+                            path: './programs/safely_remove_hardware.svelte'
+                        })
+                    }
+                }
+            ]
+        ]
+    }
+}

--- a/src/lib/components/xp/context_menu/CMTrayWindowsUpdate.js
+++ b/src/lib/components/xp/context_menu/CMTrayWindowsUpdate.js
@@ -1,0 +1,23 @@
+import { queueProgram } from '../../../store';
+
+export let make = ({type, originator}) => {
+    return {
+        required_width: 200,
+        required_height: 27 + 20,
+        menu: [
+            [
+                {
+                    name: 'Open Windows Update',
+                    font: 'bold',
+                    action: () => {
+                        queueProgram.set({
+                            name: 'Windows Update',
+                            icon: '/images/xp/icons/WindowsUpdate.png',
+                            path: './programs/windows_update.svelte'
+                        })
+                    }
+                }
+            ]
+        ]
+    }
+}

--- a/src/routes/xp/programs/network_status.svelte
+++ b/src/routes/xp/programs/network_status.svelte
@@ -1,0 +1,31 @@
+<svelte:options accessors={true} />
+<script>
+    import Window from "../../../lib/components/xp/Window.svelte";
+    import { runningPrograms } from "../../../lib/store";
+
+    export let id;
+    export let window;
+    export let self;
+    export let parentNode;
+    export let exec_path;
+
+    export function destroy(){
+        runningPrograms.update(programs => programs.filter(p => p !== self));
+        self.$destroy();
+    }
+
+    export let options = {
+        title: 'Network Connections',
+        width: 300,
+        height: 200,
+        icon: '/images/xp/icons/ConnectionStatus.png',
+        id,
+        exec_path,
+    };
+</script>
+
+<Window bind:this={window} on_click_close={destroy} {options}>
+    <div slot="content" class="p-4 text-sm">
+        Network status details are not implemented.
+    </div>
+</Window>

--- a/src/routes/xp/programs/safely_remove_hardware.svelte
+++ b/src/routes/xp/programs/safely_remove_hardware.svelte
@@ -1,0 +1,31 @@
+<svelte:options accessors={true} />
+<script>
+    import Window from "../../../lib/components/xp/Window.svelte";
+    import { runningPrograms } from "../../../lib/store";
+
+    export let id;
+    export let window;
+    export let self;
+    export let parentNode;
+    export let exec_path;
+
+    export function destroy(){
+        runningPrograms.update(programs => programs.filter(p => p !== self));
+        self.$destroy();
+    }
+
+    export let options = {
+        title: 'Safely Remove Hardware',
+        width: 300,
+        height: 200,
+        icon: '/images/xp/icons/SafelyRemoveHardware.png',
+        id,
+        exec_path,
+    };
+</script>
+
+<Window bind:this={window} on_click_close={destroy} {options}>
+    <div slot="content" class="p-4 text-sm">
+        No removable devices found.
+    </div>
+</Window>

--- a/src/routes/xp/programs/windows_update.svelte
+++ b/src/routes/xp/programs/windows_update.svelte
@@ -1,0 +1,31 @@
+<svelte:options accessors={true} />
+<script>
+    import Window from "../../../lib/components/xp/Window.svelte";
+    import { runningPrograms } from "../../../lib/store";
+
+    export let id;
+    export let window;
+    export let self;
+    export let parentNode;
+    export let exec_path;
+
+    export function destroy(){
+        runningPrograms.update(programs => programs.filter(p => p !== self));
+        self.$destroy();
+    }
+
+    export let options = {
+        title: 'Windows Update',
+        width: 400,
+        height: 250,
+        icon: '/images/xp/icons/WindowsUpdate.png',
+        id,
+        exec_path,
+    };
+</script>
+
+<Window bind:this={window} on_click_close={destroy} {options}>
+    <div slot="content" class="p-4 text-sm">
+        Windows Update is not available.
+    </div>
+</Window>

--- a/src/routes/xp/system_tray.svelte
+++ b/src/routes/xp/system_tray.svelte
@@ -1,6 +1,6 @@
 <script>
     import { onMount, onDestroy } from 'svelte';
-    import { queueProgram, systemVolume } from '../../lib/store';
+    import { queueProgram, systemVolume, contextMenu } from '../../lib/store';
     import TrayIcon from '../../lib/components/xp/TrayIcon.svelte';
 
     let time = get_time();
@@ -27,6 +27,35 @@
         program.self = program;
     }
 
+    function open_network_status(){
+        queueProgram.set({
+            name: 'Network Connections',
+            icon: '/images/xp/icons/ConnectionStatus.png',
+            path: './programs/network_status.svelte'
+        });
+    }
+
+    function open_safely_remove(){
+        queueProgram.set({
+            name: 'Safely Remove Hardware',
+            icon: '/images/xp/icons/SafelyRemoveHardware.png',
+            path: './programs/safely_remove_hardware.svelte'
+        });
+    }
+
+    function open_windows_update(){
+        queueProgram.set({
+            name: 'Windows Update',
+            icon: '/images/xp/icons/WindowsUpdate.png',
+            path: './programs/windows_update.svelte'
+        });
+    }
+
+    function show_context_menu(type, ev){
+        contextMenu.set(null);
+        contextMenu.set({x: ev.x, y: ev.y, type, originator: {}});
+    }
+
 </script>
 
 <style>
@@ -50,6 +79,15 @@
                     path: './programs/xp_tour.svelte'
                 })
             }}></TrayIcon>
+    <TrayIcon icon="/images/xp/icons/ConnectionStatus.png" tooltip_message="Local Area Connection"
+            on_click={open_network_status}
+            on_contextmenu={(ev) => show_context_menu('TrayNetwork', ev)}></TrayIcon>
+    <TrayIcon icon="/images/xp/icons/SafelyRemoveHardware.png" tooltip_message="Safely Remove Hardware"
+            on_click={open_safely_remove}
+            on_contextmenu={(ev) => show_context_menu('TraySafelyRemove', ev)}></TrayIcon>
+    <TrayIcon icon="/images/xp/icons/WindowsUpdate.png" tooltip_message="Automatic Updates"
+            on_click={open_windows_update}
+            on_contextmenu={(ev) => show_context_menu('TrayWindowsUpdate', ev)}></TrayIcon>
     <TrayIcon icon="/images/xp/icons/SecurityError.png"></TrayIcon>
     <TrayIcon icon="{$systemVolume > 0.03 ? '/images/xp/icons/Volume.png' : '/images/xp/icons/Mute.png'}" tooltip_message="Adjust volume" on_click={open_volume_adjust}></TrayIcon>
     <span class="text-slate-50 text-[11px] px-1">{time}</span>

--- a/src/routes/xp/work_space.svelte
+++ b/src/routes/xp/work_space.svelte
@@ -277,6 +277,39 @@
             runningPrograms.update(values => {
                 return [...values, program];
             })
+        } else if(path == './programs/network_status.svelte'){
+            const Program = (await import('./programs/network_status.svelte')).default;
+            let program = new Program({
+                target: node_ref,
+                props: {id: short.generate(), parentNode: node_ref, exec_path: path}
+            });
+            program.self = program;
+            //add to program tray
+            runningPrograms.update(values => {
+                return [...values, program];
+            })
+        } else if(path == './programs/safely_remove_hardware.svelte'){
+            const Program = (await import('./programs/safely_remove_hardware.svelte')).default;
+            let program = new Program({
+                target: node_ref,
+                props: {id: short.generate(), parentNode: node_ref, exec_path: path}
+            });
+            program.self = program;
+            //add to program tray
+            runningPrograms.update(values => {
+                return [...values, program];
+            })
+        } else if(path == './programs/windows_update.svelte'){
+            const Program = (await import('./programs/windows_update.svelte')).default;
+            let program = new Program({
+                target: node_ref,
+                props: {id: short.generate(), parentNode: node_ref, exec_path: path}
+            });
+            program.self = program;
+            //add to program tray
+            runningPrograms.update(values => {
+                return [...values, program];
+            })
         } else if(path == './programs/flash_player.svelte'){
             const Program = (await import('./programs/flash_player.svelte')).default;
             let program = new Program({


### PR DESCRIPTION
## Summary
- add network status, safely remove hardware, and Windows Update tray icons
- open new dialogs for tray icon actions and context menus
- wire tray icon context menus through context menu store

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688f4083f65c8329adc30ddbac6e3e86