### PR TITLE
feat: add Luna theme selector

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -46,14 +46,8 @@
   src: url('/fonts/tahoma.ttf');
 }
 
+/* Theme variables are set dynamically via the theme store */
 :root {
-  --xp-gradient: rgb(31, 47, 134) 0px, rgb(49, 101, 196) 3%, rgb(54, 130, 229) 6%, rgb(68, 144, 230) 10%, rgb(56, 131, 229) 12%, rgb(43, 113, 224) 15%, rgb(38, 99, 218) 18%, rgb(35, 91, 214) 20%, rgb(34, 88, 213) 23%, rgb(33, 87, 214) 38%, rgb(36, 93, 219) 54%, rgb(37, 98, 223) 86%, rgb(36, 95, 220) 89%, rgb(33, 88, 212) 92%, rgb(29, 78, 192) 95%, rgb(25, 65, 165) 98%;
-  --titlebar-gradient: 180deg,#0997ff,#0053ee 8%,#0050ee 40%,#06f 88%,#06f 93%,#005bff 95%,#003dd7 96%,#003dd7;
-  --titlebar-gradient-inactive: rgb(118, 151, 231) 0%, rgb(126, 158, 227) 3%, rgb(148, 175, 232) 6%, rgb(151, 180, 233) 8%, rgb(130, 165, 228) 14%, rgb(124, 159, 226) 17%, rgb(121, 150, 222) 25%, rgb(123, 153, 225) 56%, rgb(130, 169, 233) 81%, rgb(128, 165, 231) 89%, rgb(123, 150, 225) 94%, rgb(122, 147, 223) 97%, rgb(171, 186, 227) 100%;
-  --window-box-shadow-inactive: inset -1px -1px rgb(130, 165, 228), inset 1px 1px rgb(130, 165, 228), inset -2px -2px rgb(130, 165, 228), inset 2px 2px rgb(130, 165, 228), inset -3px -3px rgb(130, 165, 228), inset 3px 3px rgb(130, 165, 228);
-  --window-box-shadow:inset -1px -1px #424fa2, inset 1px 1px #4e68d1, inset -2px -2px #5669c0, inset 2px 2px #528eef, inset -3px -3px #4e73d7, inset 3px 3px #5284da;
-  --tile-box-shadow: rgb(0 0 0 / 30%) -1px 0px inset, rgb(255 255 255 / 20%) 1px 1px 1px inset;
-  --tile-box-shadow-focus: rgb(0 0 0 / 20%) 0px 0px 1px 1px inset, rgb(0 0 0 / 70%) 1px 0px 1px inset;
 }
 
 html {

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store";
 import { default_wallpapers } from './system';
+import { themes, applyTheme } from './themes';
 
 export let queueProgram = writable({});
 export let runningPrograms = writable([]);
@@ -21,4 +22,17 @@ export let runHistory = writable([]);
 
 // Track visibility of the Start Menu
 export let startMenuOpen = writable(false);
+
+// Theme selection
+export let theme = writable('lunaBlue');
+
+// Apply the initial theme
+applyTheme(themes['lunaBlue']);
+
+// Update CSS variables when the theme changes
+theme.subscribe(value => {
+    if (themes[value]) {
+        applyTheme(themes[value]);
+    }
+});
 

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -1,0 +1,45 @@
+// Theme definitions for Windows XP Luna color schemes
+// Each theme maps custom properties used throughout the UI
+
+export const themes = {
+    lunaBlue: {
+        name: 'Luna Blue',
+        'xp-gradient': 'rgb(31, 47, 134) 0px, rgb(49, 101, 196) 3%, rgb(54, 130, 229) 6%, rgb(68, 144, 230) 10%, rgb(56, 131, 229) 12%, rgb(43, 113, 224) 15%, rgb(38, 99, 218) 18%, rgb(35, 91, 214) 20%, rgb(34, 88, 213) 23%, rgb(33, 87, 214) 38%, rgb(36, 93, 219) 54%, rgb(37, 98, 223) 86%, rgb(36, 95, 220) 89%, rgb(33, 88, 212) 92%, rgb(29, 78, 192) 95%, rgb(25, 65, 165) 98%',
+        'titlebar-gradient': '180deg,#0997ff,#0053ee 8%,#0050ee 40%,#06f 88%,#06f 93%,#005bff 95%,#003dd7 96%,#003dd7',
+        'titlebar-gradient-inactive': 'rgb(118, 151, 231) 0%, rgb(126, 158, 227) 3%, rgb(148, 175, 232) 6%, rgb(151, 180, 233) 8%, rgb(130, 165, 228) 14%, rgb(124, 159, 226) 17%, rgb(121, 150, 222) 25%, rgb(123, 153, 225) 56%, rgb(130, 169, 233) 81%, rgb(128, 165, 231) 89%, rgb(123, 150, 225) 94%, rgb(122, 147, 223) 97%, rgb(171, 186, 227) 100%',
+        'window-box-shadow-inactive': 'inset -1px -1px rgb(130, 165, 228), inset 1px 1px rgb(130, 165, 228), inset -2px -2px rgb(130, 165, 228), inset 2px 2px rgb(130, 165, 228), inset -3px -3px rgb(130, 165, 228), inset 3px 3px rgb(130, 165, 228)',
+        'window-box-shadow': 'inset -1px -1px #424fa2, inset 1px 1px #4e68d1, inset -2px -2px #5669c0, inset 2px 2px #528eef, inset -3px -3px #4e73d7, inset 3px 3px #5284da',
+        'tile-box-shadow': 'rgb(0 0 0 / 30%) -1px 0px inset, rgb(255 255 255 / 20%) 1px 1px 1px inset',
+        'tile-box-shadow-focus': 'rgb(0 0 0 / 20%) 0px 0px 1px 1px inset, rgb(0 0 0 / 70%) 1px 0px 1px inset'
+    },
+    lunaOlive: {
+        name: 'Luna Olive',
+        'xp-gradient': 'rgb(84, 96, 43) 0%, rgb(176, 196, 128) 100%',
+        'titlebar-gradient': '180deg,#c5d39e,#96aa39 8%,#82a20b 40%,#8ba80c 88%,#8aa70b 93%,#778f00 95%,#5c7f00 96%,#4b6b00',
+        'titlebar-gradient-inactive': 'rgb(204, 214, 171) 0%, rgb(182, 198, 144) 100%',
+        'window-box-shadow-inactive': 'inset -1px -1px #c5d39e, inset 1px 1px #c5d39e, inset -2px -2px #c5d39e, inset 2px 2px #c5d39e, inset -3px -3px #c5d39e, inset 3px 3px #c5d39e',
+        'window-box-shadow': 'inset -1px -1px #6e7d23, inset 1px 1px #90a854, inset -2px -2px #7a8e2d, inset 2px 2px #a4c359, inset -3px -3px #8ea73a, inset 3px 3px #94b13e',
+        'tile-box-shadow': 'rgb(0 0 0 / 30%) -1px 0px inset, rgb(255 255 255 / 20%) 1px 1px 1px inset',
+        'tile-box-shadow-focus': 'rgb(0 0 0 / 20%) 0px 0px 1px 1px inset, rgb(0 0 0 / 70%) 1px 0px 1px inset'
+    },
+    lunaSilver: {
+        name: 'Luna Silver',
+        'xp-gradient': 'rgb(125, 125, 125) 0%, rgb(180, 180, 180) 100%',
+        'titlebar-gradient': '180deg,#d7d7e6,#7f7fbc 8%,#7a7ab3 40%,#8181c5 88%,#8080c4 93%,#7070b2 95%,#6161a0 96%,#51518f',
+        'titlebar-gradient-inactive': 'rgb(204, 204, 204) 0%, rgb(187, 187, 187) 100%',
+        'window-box-shadow-inactive': 'inset -1px -1px #d7d7e6, inset 1px 1px #d7d7e6, inset -2px -2px #d7d7e6, inset 2px 2px #d7d7e6, inset -3px -3px #d7d7e6, inset 3px 3px #d7d7e6',
+        'window-box-shadow': 'inset -1px -1px #9d9dbb, inset 1px 1px #bfbfd7, inset -2px -2px #b3b3d1, inset 2px 2px #c9c9e1, inset -3px -3px #b1b1d4, inset 3px 3px #b7b7d8',
+        'tile-box-shadow': 'rgb(0 0 0 / 30%) -1px 0px inset, rgb(255 255 255 / 20%) 1px 1px 1px inset',
+        'tile-box-shadow-focus': 'rgb(0 0 0 / 20%) 0px 0px 1px 1px inset, rgb(0 0 0 / 70%) 1px 0px 1px inset'
+    }
+};
+
+// Apply the given theme by writing CSS variables to the :root element
+export function applyTheme(theme) {
+    if (typeof document === 'undefined' || !theme) return;
+    Object.entries(theme).forEach(([key, value]) => {
+        if (key === 'name') return;
+        document.documentElement.style.setProperty(`--${key}`, value);
+    });
+}
+

--- a/src/routes/xp/programs/display_properties.svelte
+++ b/src/routes/xp/programs/display_properties.svelte
@@ -3,7 +3,8 @@
     import Button from '../../../lib/components/xp/Button.svelte';
     import Tab from '../../../lib/components/xp/Tab.svelte';
     import {onMount } from 'svelte';
-    import { runningPrograms, wallpaper, hardDrive } from '../../../lib/store';
+    import { runningPrograms, wallpaper, hardDrive, theme } from '../../../lib/store';
+    import { themes } from '../../../lib/themes';
     import {get, set} from 'idb-keyval';
     import _, { isEqual } from 'lodash';
     import { wallpapers_folder } from '../../../lib/system';
@@ -17,6 +18,8 @@
     let wallpapers = $hardDrive[wallpapers_folder]
     .children
     .filter(el => $hardDrive[el].type == 'file');
+
+    let selected = 'Desktop';
 
     onMount(() => {
     })
@@ -63,44 +66,55 @@
 <Window options={options} bind:this={window} on_click_close={destroy}>
     
     <div slot="content" class="absolute inset-1 p-2 pb-1 flex flex-col bg-xp-yellow overflow-hidden">
-        <Tab size={'sm'} items={['Themes', 'Desktop', 'Screesaver', 'Appearance', 'Settings']} 
-            selected={'Desktop'}>
+        <Tab size={'sm'} items={['Themes', 'Desktop', 'Screesaver', 'Appearance', 'Settings']}
+            bind:selected={selected}>
         </Tab>
         <div class="w-full grow bg-[#fafaf9]  shadow-sm -mt-[1px] flex flex-col overflow-hidden">
-            <div class="h-[250px] shrink-0 relative">
-                <div class="absolute top-8 left-1/2 -translate-x-1/2 w-[190px] h-[190px]">
-                    <div class="w-full h-full relative">
-                        {#await get_wallpaper_url(preview)}
-                            <div class="absolute bg-cover" 
-                                style="inset:10px 10px 30px 10px;">
-                            </div>
-                        {:then url} 
-                            <div class="absolute bg-cover" 
-                                style="inset:10px 10px 30px 10px;"
-                                style:background-image="url({url})">
-                            </div>
-                        {/await}
-                        <div class="absolute inset-0 bg-cover bg-[url(/images/xp/crt_monitor.png)]">
-
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="grow flex flex-row text-[13px] p-2 text-slate-800 overflow-hidden">
-                <div class="grow flex flex-col overflow-hidden">
-                    <span class="my-1">Background</span>
-                    <div class="grow p-1 overflow-y-scroll overflow-x-hidden border border-slate-700">
-                        {#each wallpapers as wallpaper}
-                        <div class="w-full flex flex-row" on:click={() => preview = wallpaper}>
-                            <img src="/images/xp/icons/JPG.png" class="w-[20px] h-[20px] shrink-0" alt="">
-                            <p class="leading-[20px] ml-1 px-1 grow-0 line-clamp-1 {_.isEqual(preview, wallpaper) ? 'bg-blue-600 text-slate-50' : ''}">
-                                {$hardDrive[wallpaper].basename}
-                            </p>
-                        </div>
+            {#if selected === 'Themes'}
+                <div class="p-4 text-[13px] text-slate-800">
+                    <label class="mb-2 block" for="theme-select">Theme</label>
+                    <select id="theme-select" class="border border-slate-700 w-full" bind:value={$theme}>
+                        {#each Object.entries(themes) as [key, t]}
+                            <option value={key}>{t.name}</option>
                         {/each}
+                    </select>
+                </div>
+            {:else}
+                <div class="h-[250px] shrink-0 relative">
+                    <div class="absolute top-8 left-1/2 -translate-x-1/2 w-[190px] h-[190px]">
+                        <div class="w-full h-full relative">
+                            {#await get_wallpaper_url(preview)}
+                                <div class="absolute bg-cover"
+                                    style="inset:10px 10px 30px 10px;">
+                                </div>
+                            {:then url}
+                                <div class="absolute bg-cover"
+                                    style="inset:10px 10px 30px 10px;"
+                                    style:background-image="url({url})">
+                                </div>
+                            {/await}
+                            <div class="absolute inset-0 bg-cover bg-[url(/images/xp/crt_monitor.png)]">
+
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
+                <div class="grow flex flex-row text-[13px] p-2 text-slate-800 overflow-hidden">
+                    <div class="grow flex flex-col overflow-hidden">
+                        <span class="my-1">Background</span>
+                        <div class="grow p-1 overflow-y-scroll overflow-x-hidden border border-slate-700">
+                            {#each wallpapers as wallpaper}
+                            <div class="w-full flex flex-row" on:click={() => preview = wallpaper}>
+                                <img src="/images/xp/icons/JPG.png" class="w-[20px] h-[20px] shrink-0" alt="">
+                                <p class="leading-[20px] ml-1 px-1 grow-0 line-clamp-1 {_.isEqual(preview, wallpaper) ? 'bg-blue-600 text-slate-50' : ''}">
+                                    {$hardDrive[wallpaper].basename}
+                                </p>
+                            </div>
+                            {/each}
+                        </div>
+                    </div>
+                </div>
+            {/if}
         </div>
         <div class="shrink-0 flex flex-row justify-end items-center px-1 pt-2">
             <Button title="OK" style="margin-right:10px;" on_click={apply}></Button>


### PR DESCRIPTION
## Summary
- extract XP style variables to theme objects
- add theme store and theme selector UI
- use theme-based variables in global styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688ff56bdf5883299ce95649af03871c