### PR TITLE
Guard tooltip rendering against injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "vite dev",
     "build": "vite build",
     "package": "svelte-kit package",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test test/tooltip.test.js"
   },
   "devDependencies": {
     "@jhubbardsf/svelte-sortablejs": "^1.1.0",

--- a/src/lib/components/xp/tooltip.js
+++ b/src/lib/components/xp/tooltip.js
@@ -38,10 +38,12 @@ export function tooltip(element) {
 		comp.style.overflow = 'hidden';
 		comp.style.padding = '4px';
                 comp.style.fontFamily = 'Tahoma, MSSS';
-		comp.innerHTML = `
-			<p class=" line-clamp-1 leading-tight text-ellipsis" style="font-size:11px;">
-				${tooltip_message}
-			</p>`;
+
+                const p = document.createElement('p');
+                p.className = ' line-clamp-1 leading-tight text-ellipsis';
+                p.style.fontSize = '11px';
+                p.textContent = tooltip_message;
+                comp.appendChild(p);
 
 		timeout = setTimeout(() => {
 			document.body.appendChild(comp);
@@ -56,8 +58,9 @@ export function tooltip(element) {
 		clearTimeout(timeout);
 		if(comp != null){
 			comp.remove();
-		}
-	}
+        }
+}
+
 	
 	element.addEventListener('mouseenter', mouseEnter);
   	element.addEventListener('mouseleave', mouseLeave);

--- a/test/tooltip.test.js
+++ b/test/tooltip.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { tooltip } from '../src/lib/components/xp/tooltip.js';
+
+test('script tags in tooltip attribute are neutralized', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.HTMLElement = window.HTMLElement;
+  global.Event = window.Event;
+  global.MouseEvent = window.MouseEvent;
+
+  const element = document.createElement('div');
+  const scriptContent = '<script>globalThis.evil = true</script>';
+  element.setAttribute('tooltip', scriptContent);
+  document.body.appendChild(element);
+
+  tooltip(element);
+  element.dispatchEvent(new window.Event('mouseenter'));
+
+  await new Promise((r) => setTimeout(r, 2100));
+
+  const tooltipDiv = document.body.lastElementChild;
+  const paragraph = tooltipDiv.querySelector('p');
+  assert.equal(paragraph.textContent, scriptContent);
+  assert.equal(document.querySelector('script'), null);
+  assert.equal(globalThis.evil, undefined);
+});


### PR DESCRIPTION
## Summary
- avoid using `innerHTML` when rendering tooltips; add text node instead
- add test that verifies scripts in tooltip attributes are inert

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890ee43e278832989dbce89e70279a9