### PR TITLE
Use Solid program paths for context menus

### DIFF
--- a/src/lib/components/xp/context_menu/CMDesktop.js
+++ b/src/lib/components/xp/context_menu/CMDesktop.js
@@ -135,7 +135,7 @@ export let make = ({type, originator}) => {
                         setQueueProgram({
                             name: 'Display Properties',
                             icon: 'DisplayProperties.png',
-                            path: './programs/display_properties.svelte'
+                            path: './programs/display_properties.jsx'
                         })
                     }
                 }

--- a/src/lib/components/xp/context_menu/CMFSItem.js
+++ b/src/lib/components/xp/context_menu/CMFSItem.js
@@ -60,7 +60,7 @@ export let make = ({type, originator}) => {
                         icon: '/images/xp/icons/RAR.png',
                         action: () => {
                             setQueueProgram({
-                                path: './programs/winrar.svelte',
+                                path: './programs/winrar.jsx',
                                 fs_item: originator.item
                             })
                         }
@@ -72,7 +72,7 @@ export let make = ({type, originator}) => {
                         icon: '/images/xp/icons/RAR.png',
                         action: () => {
                             setQueueProgram({
-                                path: './programs/zip.svelte',
+                                path: './programs/zip.jsx',
                                 fs_item: originator.item
                             })
                         }
@@ -101,7 +101,7 @@ export let make = ({type, originator}) => {
                                 icon: '/images/xp/icons/Zipfolder.png',
                                 action: () => {
                                     setQueueProgram({
-                                        path: './programs/zip.svelte',
+                                        path: './programs/zip.jsx',
                                         fs_item: originator.item
                                     })
                                 }
@@ -216,12 +216,12 @@ export let make = ({type, originator}) => {
                     action: () => {
                         if(originator.item.type == 'drive' || originator.item.type == 'removable_storage'){
                             setQueueProgram({
-                                path: './programs/disk_properties.svelte',
+                                path: './programs/disk_properties.jsx',
                                 fs_item: originator.item
                             })
                         } else {
                             setQueueProgram({
-                                path: './programs/properties.svelte',
+                                path: './programs/properties.jsx',
                                 fs_item: originator.item
                             })
                         }

--- a/src/lib/components/xp/context_menu/CMFSVoid.js
+++ b/src/lib/components/xp/context_menu/CMFSVoid.js
@@ -140,12 +140,12 @@ export let make = ({type, originator}) => {
                         let fs_item = hardDrive()[originator.id];
                         if(fs_item.type == 'drive' || fs_item.type == 'removable_storage'){
                             setQueueProgram({
-                                path: './programs/disk_properties.svelte',
+                                path: './programs/disk_properties.jsx',
                                 fs_item
                             })
                         } else {
                             setQueueProgram({
-                                path: './programs/properties.svelte',
+                                path: './programs/properties.jsx',
                                 fs_item
                             })
                         }

--- a/src/lib/components/xp/context_menu/CMTrayNetwork.js
+++ b/src/lib/components/xp/context_menu/CMTrayNetwork.js
@@ -13,7 +13,7 @@ export let make = ({type, originator}) => {
                         setQueueProgram({
                             name: 'Network Connections',
                             icon: '/images/xp/icons/ConnectionStatus.png',
-                            path: './programs/network_status.svelte'
+                            path: './programs/network_status.jsx'
                         })
                     }
                 }

--- a/src/lib/components/xp/context_menu/CMTraySafelyRemove.js
+++ b/src/lib/components/xp/context_menu/CMTraySafelyRemove.js
@@ -13,7 +13,7 @@ export let make = ({type, originator}) => {
                         setQueueProgram({
                             name: 'Safely Remove Hardware',
                             icon: '/images/xp/icons/SafelyRemoveHardware.png',
-                            path: './programs/safely_remove_hardware.svelte'
+                            path: './programs/safely_remove_hardware.jsx'
                         })
                     }
                 }

--- a/src/lib/components/xp/context_menu/CMTrayWindowsUpdate.js
+++ b/src/lib/components/xp/context_menu/CMTrayWindowsUpdate.js
@@ -13,7 +13,7 @@ export let make = ({type, originator}) => {
                         setQueueProgram({
                             name: 'Windows Update',
                             icon: '/images/xp/icons/WindowsUpdate.png',
-                            path: './programs/windows_update.svelte'
+                            path: './programs/windows_update.jsx'
                         })
                     }
                 }

--- a/src/lib/components/xp/context_menu/RecycleBin.js
+++ b/src/lib/components/xp/context_menu/RecycleBin.js
@@ -48,7 +48,7 @@ export let make = ({type, originator}) => {
                     name: 'Properties',
                     action: () => {
                         // queueProgram.set({
-                        //     path: './programs/properties.svelte',
+                        //     path: './programs/properties.jsx',
                         //     fs_item: originator.item
                         // })
                     }

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -159,7 +159,7 @@ let ie_program = {
   name: 'Microsoft Internet Explorer'
 }
 let winrar_program = {
-  path: './programs/winrar.svelte',
+  path: './programs/winrar.jsx',
   icon: '/images/xp/icons/RAR.png',
   name: 'WinRAR'
 }

--- a/src/routes/programs/disk_properties.jsx
+++ b/src/routes/programs/disk_properties.jsx
@@ -1,0 +1,8 @@
+export default function DiskProperties() {
+  return (
+    <div class="p-4 text-sm">
+      Disk Properties program placeholder.
+    </div>
+  );
+}
+

--- a/src/routes/programs/display_properties.jsx
+++ b/src/routes/programs/display_properties.jsx
@@ -1,0 +1,8 @@
+export default function DisplayProperties() {
+  return (
+    <div class="p-4 text-sm">
+      Display Properties program placeholder.
+    </div>
+  );
+}
+

--- a/src/routes/programs/network_status.jsx
+++ b/src/routes/programs/network_status.jsx
@@ -1,0 +1,8 @@
+export default function NetworkStatus() {
+  return (
+    <div class="p-4 text-sm">
+      Network status utility placeholder.
+    </div>
+  );
+}
+

--- a/src/routes/programs/properties.jsx
+++ b/src/routes/programs/properties.jsx
@@ -1,0 +1,8 @@
+export default function Properties() {
+  return (
+    <div class="p-4 text-sm">
+      Properties viewer placeholder.
+    </div>
+  );
+}
+

--- a/src/routes/programs/safely_remove_hardware.jsx
+++ b/src/routes/programs/safely_remove_hardware.jsx
@@ -1,0 +1,8 @@
+export default function SafelyRemoveHardware() {
+  return (
+    <div class="p-4 text-sm">
+      Safely Remove Hardware utility placeholder.
+    </div>
+  );
+}
+

--- a/src/routes/programs/windows_update.jsx
+++ b/src/routes/programs/windows_update.jsx
@@ -1,0 +1,8 @@
+export default function WindowsUpdate() {
+  return (
+    <div class="p-4 text-sm">
+      Windows Update placeholder.
+    </div>
+  );
+}
+

--- a/src/routes/programs/winrar.jsx
+++ b/src/routes/programs/winrar.jsx
@@ -1,0 +1,8 @@
+export default function WinRAR() {
+  return (
+    <div class="p-4 text-sm">
+      WinRAR functionality is not implemented.
+    </div>
+  );
+}
+

--- a/src/routes/programs/zip.jsx
+++ b/src/routes/programs/zip.jsx
@@ -1,0 +1,8 @@
+export default function Zip() {
+  return (
+    <div class="p-4 text-sm">
+      Zip archive utility placeholder.
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- route context menu actions to Solid JSX program modules instead of Svelte files
- stub out Solid program components like Display Properties, WinRAR, Zip and more
- standardize WinRAR program path in system definitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68911b9066a88329adcdbd3c2943878c