### PR TITLE
feat: add persistent theme settings

### DIFF
--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -46,6 +46,7 @@ createEffect(() => {
   if (themes[value]) {
     applyTheme(themes[value]);
   }
+  persist("theme", value);
 });
 
 // Persist users and current user when they change
@@ -74,5 +75,14 @@ export async function loadUsers() {
   const current = await get("current_user");
   if (current) {
     setCurrentUser(current);
+  }
+}
+
+// Load selected theme from IndexedDB
+export async function loadTheme() {
+  if (typeof indexedDB === "undefined") return;
+  const stored = await get("theme");
+  if (stored && themes[stored]) {
+    setTheme(stored);
   }
 }

--- a/src/routes/programs/display_properties.jsx
+++ b/src/routes/programs/display_properties.jsx
@@ -1,7 +1,8 @@
 import { For } from "solid-js";
 import { set } from "idb-keyval";
 import { default_wallpapers } from "../../lib/system";
-import { wallpaper, setWallpaper } from "../../lib/store";
+import { wallpaper, setWallpaper, theme, setTheme } from "../../lib/store";
+import { themes } from "../../lib/themes";
 
 export default function DisplayProperties() {
   async function apply(path) {
@@ -12,19 +13,38 @@ export default function DisplayProperties() {
   }
 
   return (
-    <div class="p-4 text-sm">
-      <div class="grid grid-cols-3 gap-2">
-        <For each={default_wallpapers}>
-          {(wp) => (
-            <button
-              class={`border p-1 text-left ${wallpaper() === wp.path ? "border-blue-500" : "border-gray-300"}`}
-              onClick={() => apply(wp.path)}
-            >
-              <img src={wp.path} alt={wp.name} class="w-24 h-16 object-cover" />
-              <div class="mt-1">{wp.name}</div>
-            </button>
-          )}
-        </For>
+    <div class="p-4 text-sm space-y-4">
+      <div>
+        <div class="mb-2 font-semibold">Themes</div>
+        <div class="flex gap-2 flex-wrap">
+          <For each={Object.entries(themes)}>
+            {([key, t]) => (
+              <button
+                class={`px-2 py-1 border ${theme() === key ? "border-blue-500" : "border-gray-300"}`}
+                onClick={() => setTheme(key)}
+              >
+                {t.name}
+              </button>
+            )}
+          </For>
+        </div>
+      </div>
+
+      <div>
+        <div class="mb-2 font-semibold">Wallpapers</div>
+        <div class="grid grid-cols-3 gap-2">
+          <For each={default_wallpapers}>
+            {(wp) => (
+              <button
+                class={`border p-1 text-left ${wallpaper() === wp.path ? "border-blue-500" : "border-gray-300"}`}
+                onClick={() => apply(wp.path)}
+              >
+                <img src={wp.path} alt={wp.name} class="w-24 h-16 object-cover" />
+                <div class="mt-1">{wp.name}</div>
+              </button>
+            )}
+          </For>
+        </div>
       </div>
     </div>
   );

--- a/src/routes/xp/login.jsx
+++ b/src/routes/xp/login.jsx
@@ -12,7 +12,8 @@ import {
   setUsers,
   currentUser,
   setCurrentUser,
-  loadUsers
+  loadUsers,
+  loadTheme
 } from "../../lib/store";
 import { bliss_wallpaper, SortOptions, SortOrders } from "../../lib/system";
 import { useNavigate } from "@solidjs/router";
@@ -24,6 +25,7 @@ export default function Login() {
   const [password, setPassword] = createSignal("");
 
   onMount(async () => {
+    await loadTheme();
     await loadUsers();
     setProfiles(users());
     await loadHardDrive();

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { queueProgram, setQueueProgram } from '../src/lib/store.js';
+import { queueProgram, setQueueProgram, theme, setTheme } from '../src/lib/store.js';
 
 test('queueProgram defaults to empty object', () => {
   assert.deepStrictEqual(queueProgram(), {});
@@ -9,4 +9,13 @@ test('queueProgram defaults to empty object', () => {
 test('queueProgram can be updated', () => {
   setQueueProgram({ id: 1 });
   assert.deepStrictEqual(queueProgram(), { id: 1 });
+});
+
+test('theme defaults to lunaBlue', () => {
+  assert.strictEqual(theme(), 'lunaBlue');
+});
+
+test('theme can be updated', () => {
+  setTheme('lunaOlive');
+  assert.strictEqual(theme(), 'lunaOlive');
 });


### PR DESCRIPTION
## Summary
- add theme storage and loader
- add theme selection to display properties
- cover theme updates in store tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68915a1712dc8329a4da530850579eb5