### PR TITLE
Implement screensaver functionality

### DIFF
--- a/src/lib/screensavers.js
+++ b/src/lib/screensavers.js
@@ -1,0 +1,7 @@
+export const screensavers = [
+  { name: 'None', path: null },
+  ...Array.from({ length: 12 }, (_, i) => ({
+    name: `Screensaver ${i + 1}`,
+    path: `/html/visualizers/${i + 1}.html`
+  }))
+];

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -11,6 +11,9 @@ export const [zIndex, setZIndex] = createSignal(0);
 
 export const [wallpaper, setWallpaper] = createSignal(null);
 
+export const [screensaver, setScreensaver] = createSignal(null);
+export const [screensaverTimeout, setScreensaverTimeout] = createSignal(5);
+
 export const [systemVolume, setSystemVolume] = createSignal(1);
 
 export const [hardDrive, setHardDrive] = createSignal(null);
@@ -53,6 +56,8 @@ createEffect(() => {
 createEffect(() => persist("users", users()));
 createEffect(() => persist("current_user", currentUser()));
 createEffect(() => persist("wallpaper", wallpaper()));
+createEffect(() => persist("screensaver", screensaver()));
+createEffect(() => persist("screensaverTimeout", screensaverTimeout()));
 
 // Apply wallpaper to page background
 createEffect(() => {
@@ -84,5 +89,17 @@ export async function loadTheme() {
   const stored = await get("theme");
   if (stored && themes[stored]) {
     setTheme(stored);
+  }
+}
+
+export async function loadScreensaver() {
+  if (typeof indexedDB === "undefined") return;
+  const ss = await get("screensaver");
+  const timeout = await get("screensaverTimeout");
+  if (ss != null) {
+    setScreensaver(ss);
+  }
+  if (timeout != null) {
+    setScreensaverTimeout(timeout);
   }
 }

--- a/src/routes/programs/display_properties.jsx
+++ b/src/routes/programs/display_properties.jsx
@@ -1,7 +1,17 @@
 import { For } from "solid-js";
 import { set } from "idb-keyval";
 import { default_wallpapers } from "../../lib/system";
-import { wallpaper, setWallpaper, theme, setTheme } from "../../lib/store";
+import { screensavers } from "../../lib/screensavers";
+import {
+  wallpaper,
+  setWallpaper,
+  theme,
+  setTheme,
+  screensaver,
+  setScreensaver,
+  screensaverTimeout,
+  setScreensaverTimeout,
+} from "../../lib/store";
 import { themes } from "../../lib/themes";
 
 export default function DisplayProperties() {
@@ -9,6 +19,13 @@ export default function DisplayProperties() {
     setWallpaper(path);
     if (typeof indexedDB !== "undefined") {
       await set("wallpaper", path);
+    }
+  }
+
+  function preview() {
+    const ss = screensaver();
+    if (ss) {
+      window.open(`/screensaver?src=${encodeURIComponent(ss)}`, "_blank");
     }
   }
 
@@ -44,6 +61,35 @@ export default function DisplayProperties() {
               </button>
             )}
           </For>
+        </div>
+      </div>
+
+      <div>
+        <div class="mb-2 font-semibold">Screen Saver</div>
+        <div class="flex items-center gap-2">
+          <select
+            class="border p-1"
+            value={screensaver() ?? ""}
+            onInput={(e) => setScreensaver(e.currentTarget.value || null)}
+          >
+            <For each={screensavers}>
+              {(ss) => <option value={ss.path ?? ""}>{ss.name}</option>}
+            </For>
+          </select>
+          <button class="px-2 py-1 border border-gray-300" onClick={preview}>
+            Preview
+          </button>
+        </div>
+        <div class="mt-2 flex items-center gap-2">
+          <span>Wait</span>
+          <input
+            type="number"
+            min="1"
+            class="border p-1 w-16"
+            value={screensaverTimeout()}
+            onInput={(e) => setScreensaverTimeout(parseInt(e.currentTarget.value))}
+          />
+          <span>minutes</span>
         </div>
       </div>
     </div>

--- a/src/routes/screensaver.jsx
+++ b/src/routes/screensaver.jsx
@@ -1,0 +1,24 @@
+import { onMount, onCleanup } from "solid-js";
+
+export default function ScreenSaver() {
+  const params = new URLSearchParams(typeof window !== "undefined" ? window.location.search : "");
+  const src = params.get("src");
+
+  onMount(() => {
+    const exit = () => window.close();
+    window.addEventListener("mousemove", exit);
+    window.addEventListener("keydown", exit);
+    window.addEventListener("mousedown", exit);
+    onCleanup(() => {
+      window.removeEventListener("mousemove", exit);
+      window.removeEventListener("keydown", exit);
+      window.removeEventListener("mousedown", exit);
+    });
+  });
+
+  return (
+    <div class="w-screen h-screen overflow-hidden">
+      {src && <iframe src={src} class="w-full h-full border-0" title="screensaver" />}
+    </div>
+  );
+}

--- a/src/routes/xp/login.jsx
+++ b/src/routes/xp/login.jsx
@@ -13,7 +13,8 @@ import {
   currentUser,
   setCurrentUser,
   loadUsers,
-  loadTheme
+  loadTheme,
+  loadScreensaver
 } from "../../lib/store";
 import { bliss_wallpaper, SortOptions, SortOrders } from "../../lib/system";
 import { useNavigate } from "@solidjs/router";
@@ -30,6 +31,7 @@ export default function Login() {
     setProfiles(users());
     await loadHardDrive();
     await loadWallpaper();
+    await loadScreensaver();
     preloadIframes();
     preloadContextMenus();
   });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,6 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { queueProgram, setQueueProgram, theme, setTheme } from '../src/lib/store.js';
+import {
+  queueProgram,
+  setQueueProgram,
+  theme,
+  setTheme,
+  screensaver,
+  setScreensaver,
+  screensaverTimeout,
+  setScreensaverTimeout,
+} from '../src/lib/store.js';
 
 test('queueProgram defaults to empty object', () => {
   assert.deepStrictEqual(queueProgram(), {});
@@ -18,4 +27,22 @@ test('theme defaults to lunaBlue', () => {
 test('theme can be updated', () => {
   setTheme('lunaOlive');
   assert.strictEqual(theme(), 'lunaOlive');
+});
+
+test('screensaver defaults to null', () => {
+  assert.strictEqual(screensaver(), null);
+});
+
+test('screensaver can be updated', () => {
+  setScreensaver('/html/visualizers/1.html');
+  assert.strictEqual(screensaver(), '/html/visualizers/1.html');
+});
+
+test('screensaverTimeout defaults to 5', () => {
+  assert.strictEqual(screensaverTimeout(), 5);
+});
+
+test('screensaverTimeout can be updated', () => {
+  setScreensaverTimeout(10);
+  assert.strictEqual(screensaverTimeout(), 10);
 });


### PR DESCRIPTION
## Summary
- add ability to select and preview screensavers
- persist screensaver settings and timeout
- load screensaver preferences during login and provide full-screen preview route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68918165ea548329aecc788d47fa3fb9