### PR TITLE
Add hardware manager for resource caps

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -117,6 +117,27 @@ export function set_installing_windows(value){
   localStorage.setItem('is_installing_windows', value);
 }
 
+export function get_hardware_settings() {
+  let value = localStorage.getItem('hardware_settings');
+  try {
+    value = JSON.parse(value);
+  } catch (e) {
+    value = {};
+  }
+  return {
+    ram: Math.min(8192, (value?.ram ?? 128)),
+    cores: Math.min(4, (value?.cores ?? 1))
+  };
+}
+
+export function set_hardware_settings(settings = {}) {
+  const current = get_hardware_settings();
+  const updated = { ...current, ...settings };
+  updated.ram = Math.min(8192, Math.max(16, Number(updated.ram)));
+  updated.cores = Math.min(4, Math.max(1, Number(updated.cores)));
+  localStorage.setItem('hardware_settings', JSON.stringify(updated));
+}
+
 export function set_theme(theme='xp'){
   if(theme == 'xp'){
     document.querySelector('#theme').href = 'https://unpkg.com/xp.css';

--- a/src/routes/boot_manager.jsx
+++ b/src/routes/boot_manager.jsx
@@ -13,6 +13,7 @@ export default function BootManager() {
     "Install Windows",
     "Onboard NIC (IPV4)",
     "Onboard NIC (IPV6",
+    "Hardware Manager",
     "BIOS Setup",
     "Device Configuration",
     "BIOS Flash Update",
@@ -42,6 +43,8 @@ export default function BootManager() {
     } else if (currentOption() === 1) {
       utils.set_installing_windows(true);
       navigate("/installation/dos/starting");
+    } else if (currentOption() === 4) {
+      navigate("/hardware_manager");
     }
   };
 

--- a/src/routes/hardware_manager.jsx
+++ b/src/routes/hardware_manager.jsx
@@ -1,0 +1,52 @@
+import { createSignal, onMount } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import * as utils from "../lib/utils";
+
+export default function HardwareManager() {
+  const navigate = useNavigate();
+  const config = utils.get_hardware_settings();
+  const [ram, setRam] = createSignal(config.ram);
+  const [cores, setCores] = createSignal(config.cores);
+
+  const save = () => {
+    utils.set_hardware_settings({ ram: ram(), cores: cores() });
+    navigate("/boot_manager");
+  };
+
+  onMount(() => {
+    utils.set_theme("none");
+  });
+
+  return (
+    <div class="w-screen h-screen bg-black text-slate-100 font-MSSS p-8">
+      <h1 class="text-xl mb-4">Hardware Manager</h1>
+      <div class="mb-4">
+        <label class="block mb-1" for="ram">RAM (MB)</label>
+        <input
+          id="ram"
+          type="number"
+          min="16"
+          max="8192"
+          value={ram()}
+          onInput={(e) => setRam(Math.min(8192, Math.max(16, Number(e.currentTarget.value))))}
+          class="text-slate-900 p-1"
+        />
+      </div>
+      <div class="mb-4">
+        <label class="block mb-1" for="cores">CPU Cores</label>
+        <input
+          id="cores"
+          type="number"
+          min="1"
+          max="4"
+          value={cores()}
+          onInput={(e) => setCores(Math.min(4, Math.max(1, Number(e.currentTarget.value))))}
+          class="text-slate-900 p-1"
+        />
+      </div>
+      <button class="mt-4 px-4 py-2 bg-slate-200 text-slate-900" onClick={save}>
+        Save
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Hardware Manager option to boot menu
- allow configuring RAM and CPU cores with caps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6891a7d6d0b88329b2f6af363d4591dc