### PR TITLE
refactor: modernize asset generators

### DIFF
--- a/gen/imports.js
+++ b/gen/imports.js
@@ -1,16 +1,26 @@
-import path from 'path';
-import dir from 'node-dir';
+import path from 'node:path';
+import { readdir } from 'node:fs/promises';
 
-(async () => {
-    let files = dir.files('./src/routes/', {sync: true}).filter(file => path.extname(file) == '.svelte');
-    let statements = '';
-    for(let file of files){
-        let import_path = file.split('src/routes/').join('./')
-        statements = statements  + `
-        else if(url == '${import_path}'){
-            page = (await import('${import_path}')).default;
-    
-        }`
-    }
-    console.log(statements);
-})()
+async function walk(dir) {
+  const dirents = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    dirents.map(async (dirent) => {
+      const res = path.join(dir, dirent.name);
+      return dirent.isDirectory() ? await walk(res) : res;
+    })
+  );
+  return files.flat();
+}
+
+const files = (await walk('src/routes')).filter(
+  (file) => path.extname(file) === '.jsx'
+);
+
+let statements = '';
+for (const file of files) {
+  const importPath = file.replace('src/routes/', './');
+  statements += `\n  else if (url === '${importPath}') {\n    page = (await import('${importPath}')).default;\n  }`;
+}
+
+console.log(statements);
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web-solid",
       "version": "0.0.1",
+      "license": "Unlicense",
       "dependencies": {
         "@faker-js/faker": "^9.9.0",
         "axios": "^1.11.0",
@@ -24,7 +25,6 @@
         "jszip": "^3.10.1",
         "link-preview-js": "^3.1.0",
         "lodash": "^4.17.21",
-        "node-dir": "^0.1.17",
         "short-uuid": "^4.2.2",
         "solid-bootstrap": "^1.0.4",
         "solid-headless": "^0.13.1",
@@ -5403,18 +5403,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
-    },
-    "node_modules/node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10.5"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "test": "node --test test/store.test.js"
   },
   "devDependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
+    "@types/lodash": "^4.17.20",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "postcss-load-config": "^4.0.2",
-    "tailwindcss": "^3.4.17",
-    "vite": "^4.4.9",
-    "@tailwindcss/line-clamp": "^0.4.4",
-    "@types/lodash": "^4.17.20",
     "solid-start": "^0.3.2",
     "solid-start-node": "^0.3.2",
+    "tailwindcss": "^3.4.17",
+    "vite": "^4.4.9",
     "vite-plugin-solid": "^2.9.1"
   },
   "type": "module",
@@ -38,12 +38,11 @@
     "jszip": "^3.10.1",
     "link-preview-js": "^3.1.0",
     "lodash": "^4.17.21",
-    "node-dir": "^0.1.17",
     "short-uuid": "^4.2.2",
-    "srt-webvtt": "^2.0.0",
-    "tailwindcss-scoped-groups": "^2.0.0",
-    "solid-js": "^1.8.17",
+    "solid-bootstrap": "^1.0.4",
     "solid-headless": "^0.13.1",
-    "solid-bootstrap": "^1.0.4"
+    "solid-js": "^1.8.17",
+    "srt-webvtt": "^2.0.0",
+    "tailwindcss-scoped-groups": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- refactor asset generation to use fs/promises and remove node-dir
- scan JSX routes for dynamic imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6891ab870c9483298c7e17de34a4cb32