### PR TITLE
feat: integrate ruffle-based flash player

### DIFF
--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -165,7 +165,7 @@ let winrar_program = {
 }
 
 let flash_player_program = {
-  path: './programs/flash_player.svelte',
+  path: './programs/flash_player.jsx',
   icon: '/images/xp/icons/FlashPlayer.png',
   name: 'Flash Player'
 }

--- a/src/routes/programs/flash_player.jsx
+++ b/src/routes/programs/flash_player.jsx
@@ -1,0 +1,24 @@
+import { onMount } from "solid-js";
+
+export default function FlashPlayer(props) {
+  const src = props?.fs_item?.url ?? "";
+
+  onMount(() => {
+    // Load Ruffle script once
+    if (!window.RufflePlayer) {
+      window.RufflePlayer = window.RufflePlayer || {};
+      window.RufflePlayer.config = { autoplay: "auto" };
+
+      const script = document.createElement("script");
+      script.src = "https://unpkg.com/@ruffle-rs/ruffle";
+      script.async = true;
+      document.body.appendChild(script);
+    }
+  });
+
+  return (
+    <div class="w-full h-full">
+      <ruffle-player src={src} class="w-full h-full" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Ruffle-powered Flash Player program
- wire Flash files to new program

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6891b1e6b6c48329b4295db1681d08a9