### PR TITLE
feat: add first-time installation flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "solid-start dev",
     "build": "solid-start build",
     "start": "solid-start start",
-    "test": "node --test test/store.test.js"
+    "test": "node --test test/*.test.js"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,4 @@
-import mime_db from './mime.json';
+import mime_db from './mime.json' assert { type: 'json' };
 
 export function compile_params(new_params){
     
@@ -115,6 +115,16 @@ export function is_installing_windows(){
 export function set_installing_windows(value){
   value = parse_bool(value);
   localStorage.setItem('is_installing_windows', value);
+}
+
+export function is_windows_installed(){
+  let value = localStorage.getItem('windows_installed');
+  return parse_bool(value);
+}
+
+export function set_windows_installed(value){
+  value = parse_bool(value);
+  localStorage.setItem('windows_installed', value);
 }
 
 export function get_hardware_settings() {

--- a/src/routes/boot_manager.jsx
+++ b/src/routes/boot_manager.jsx
@@ -42,7 +42,7 @@ export default function BootManager() {
       navigate("/xp/login");
     } else if (currentOption() === 1) {
       utils.set_installing_windows(true);
-      navigate("/installation/dos/starting");
+      navigate("/installation");
     } else if (currentOption() === 4) {
       navigate("/hardware_manager");
     }
@@ -51,6 +51,11 @@ export default function BootManager() {
   onMount(() => {
     utils.set_theme("none");
     setIsChromium(window.chrome != null);
+    if (!utils.is_windows_installed()) {
+      utils.set_installing_windows(true);
+      navigate("/installation");
+      return;
+    }
     window.addEventListener("keydown", onKeyPressed);
   });
 

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,4 +1,19 @@
+import { onMount } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import * as utils from "../lib/utils";
+
 export default function Home() {
+  const navigate = useNavigate();
+
+  onMount(() => {
+    if (utils.is_windows_installed()) {
+      navigate("/boot_manager");
+    } else {
+      utils.set_installing_windows(true);
+      navigate("/installation");
+    }
+  });
+
   return (
     <main class="p-4">
       <h1 class="text-2xl">WIN32.run Solid</h1>

--- a/src/routes/installation/index.jsx
+++ b/src/routes/installation/index.jsx
@@ -1,0 +1,41 @@
+import { createSignal, onMount } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import * as utils from "../../lib/utils";
+
+export default function Installation() {
+  const navigate = useNavigate();
+  const [progress, setProgress] = createSignal(0);
+  const steps = [
+    "Setup is loading files...",
+    "Setup is starting Windows...",
+    "Preparing installation...",
+    "Installing Windows...",
+    "Finalizing installation..."
+  ];
+
+  onMount(() => {
+    let tick = 0;
+    const interval = setInterval(() => {
+      tick += 1;
+      setProgress(tick * 20);
+      if (tick >= 5) {
+        clearInterval(interval);
+        utils.set_windows_installed(true);
+        utils.set_installing_windows(false);
+        navigate("/xp/login");
+      }
+    }, 1000);
+  });
+
+  const message = () => steps[Math.min(steps.length - 1, Math.floor(progress() / 20))];
+
+  return (
+    <div class="w-screen h-screen bg-[#002a80] text-white font-MSSS flex flex-col items-center justify-center">
+      <h1 class="text-2xl mb-4">Windows XP Setup</h1>
+      <p class="mb-4">{message()}</p>
+      <div class="w-64 h-4 bg-black">
+        <div class="h-full bg-green-500" style={{ width: `${progress()}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { is_windows_installed, set_windows_installed } from '../src/lib/utils.js';
+
+test('installation flag stored in localStorage', () => {
+  global.localStorage = {
+    store: {},
+    getItem(key) { return this.store[key] ?? null; },
+    setItem(key, value) { this.store[key] = String(value); }
+  };
+
+  assert.strictEqual(is_windows_installed(), false);
+  set_windows_installed(true);
+  assert.strictEqual(is_windows_installed(), true);
+});


### PR DESCRIPTION
## Summary
- redirect new users to a simulated Windows XP installation screen
- store and check an installation flag to track setup completion
- extend tests to cover installation state and run all suite files

## Testing
- `npm test > /tmp/unit.log 2>&1; tail -n 20 /tmp/unit.log`
- `head -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_b_6891b3a5523c8329923aea0495d57f35