### PR TITLE
Add minimal kernel API for program installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ Files (and Folders) in win32.run are stored locally in IndexedDB. Apps (and 3rd-
 WIN32.RUN is built with [SolidJS](https://github.com/solidjs/solid)/[Solid Start](https://github.com/solidjs/solid-start) and [Tailwindcss](https://github.com/tailwindlabs/tailwindcss).
 Solid provides a lightweight React-like developer experience with fine-grained reactivity and JSX.
 
+## Kernel API
+
+win32.run now includes a minimal JavaScript kernel located at `src/lib/kernel.js`. The kernel
+allows programs to be installed and launched at runtime and exposes a simple subsystem registry
+that other features can build on top of.
+
+```javascript
+import kernel from './lib/kernel';
+
+kernel.installProgram({ id: 'demo', name: 'Demo', path: './programs/demo.jsx' });
+kernel.launchProgram('demo');
+```
+
+Subsystems can extend the kernel:
+
+```javascript
+kernel.registerSubsystem('theme', { apply: name => {/* ... */} });
+```
+
+These hooks provide a starting point for enhancing the authenticity of the emulated Windows XP
+environment.
+
 # Run, build & deploy
 I deploy it on a $5 Vultr instance, there's no special hardware and dependencies requirement here, except Node.js (and NPM).
 

--- a/src/lib/kernel.js
+++ b/src/lib/kernel.js
@@ -1,0 +1,30 @@
+import { installedPrograms, setInstalledPrograms, setQueueProgram } from './store.js';
+
+class Kernel {
+  constructor() {
+    this.subsystems = new Map();
+  }
+
+  installProgram(program) {
+    if (!program || !program.path) return;
+    setInstalledPrograms(list => [...list, program]);
+  }
+
+  launchProgram(id, fsItem = {}) {
+    const program = installedPrograms().find(p => p.id === id || p.name === id);
+    if (program) {
+      setQueueProgram({ path: program.path, fs_item: fsItem });
+    }
+  }
+
+  registerSubsystem(name, api) {
+    this.subsystems.set(name, api);
+  }
+
+  getSubsystem(name) {
+    return this.subsystems.get(name);
+  }
+}
+
+export const kernel = new Kernel();
+export default kernel;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -5,6 +5,9 @@ import { set, get, clear } from "idb-keyval";
 export const [queueProgram, setQueueProgram] = createSignal({});
 export const [runningPrograms, setRunningPrograms] = createSignal([]);
 
+// Programs installed in the emulated system
+export const [installedPrograms, setInstalledPrograms] = createSignal([]);
+
 export const [selectingItems, setSelectingItems] = createSignal([]);
 export const [contextMenu, setContextMenu] = createSignal(null);
 export const [zIndex, setZIndex] = createSignal(0);

--- a/test/kernel.test.js
+++ b/test/kernel.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import kernel from '../src/lib/kernel.js';
+import { installedPrograms, setInstalledPrograms, queueProgram, setQueueProgram } from '../src/lib/store.js';
+
+test('kernel installs programs', () => {
+  setInstalledPrograms([]);
+  kernel.installProgram({ id: 'demo', name: 'Demo', path: './programs/demo.jsx' });
+  assert.strictEqual(installedPrograms().length, 1);
+});
+
+test('kernel launches installed program', () => {
+  setInstalledPrograms([]);
+  setQueueProgram({});
+  kernel.installProgram({ id: 'demo', name: 'Demo', path: './programs/demo.jsx' });
+  kernel.launchProgram('demo');
+  assert.deepStrictEqual(queueProgram(), { path: './programs/demo.jsx', fs_item: {} });
+});


### PR DESCRIPTION
## Summary
- track installed programs via store
- expose `kernel` module to install and launch programs and register subsystems
- document kernel API and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892b3089df4832991b399f57149b3c0