### PR TITLE
Add simulated hardware abstraction layer

### DIFF
--- a/src/lib/hal/README.md
+++ b/src/lib/hal/README.md
@@ -1,0 +1,41 @@
+# Hardware Abstraction Layer (HAL)
+
+This package exposes a minimal hardware abstraction layer for kernel modules.
+It simulates basic hardware components using Node.js primitives so that code can
+interact with "hardware" without requiring access to real devices.
+
+## API
+
+### `readPort(port: number): number`
+Read the value from a simulated I/O port. Ports default to `0` if nothing was
+written.
+
+### `writePort(port: number, value: number): void`
+Write a value to a simulated I/O port.
+
+### `interruptController`
+Object used to register and trigger interrupt handlers.
+
+- `register(irq: string, handler: Function): void`
+  Register a handler for a given interrupt request number.
+- `trigger(irq: string, ...args: any[]): void`
+  Trigger a registered interrupt and pass arguments to the handler.
+- `clear(irq: string): void`
+  Remove a registered interrupt handler.
+
+### `timer`
+Provides wrappers around the Node.js timer functions.
+
+- `setTimeout(fn: Function, ms: number): Timeout`
+- `clearTimeout(id: Timeout): void`
+
+### `powerManagement`
+Simple interface to manage the simulated power state.
+
+- `shutdown(): void`
+- `reboot(): void`
+- `getState(): string` – returns the current power state (`"on"`, `"off"`, or
+  `"rebooting"`).
+
+These interfaces are designed to be imported by kernel modules to interact with
+simulated hardware in a consistent way.

--- a/src/lib/hal/index.js
+++ b/src/lib/hal/index.js
@@ -1,0 +1,60 @@
+// Hardware Abstraction Layer (HAL) simulation
+// Provides simple interfaces for kernel modules to interact with
+// simulated hardware components.
+
+// Simulated hardware ports storage
+const ports = new Map();
+
+export function readPort(port) {
+  return ports.get(port) ?? 0;
+}
+
+export function writePort(port, value) {
+  ports.set(port, value);
+}
+
+export const interruptController = (() => {
+  const handlers = new Map();
+  return {
+    register(irq, handler) {
+      handlers.set(irq, handler);
+    },
+    trigger(irq, ...args) {
+      const handler = handlers.get(irq);
+      if (handler) {
+        handler(...args);
+      }
+    },
+    clear(irq) {
+      handlers.delete(irq);
+    }
+  };
+})();
+
+export const timer = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: id => clearTimeout(id)
+};
+
+export const powerManagement = (() => {
+  let state = 'on';
+  return {
+    shutdown() {
+      state = 'off';
+    },
+    reboot() {
+      state = 'rebooting';
+    },
+    getState() {
+      return state;
+    }
+  };
+})();
+
+export default {
+  readPort,
+  writePort,
+  interruptController,
+  timer,
+  powerManagement
+};

--- a/test/hal.test.js
+++ b/test/hal.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readPort, writePort, interruptController, timer, powerManagement } from '../src/lib/hal/index.js';
+
+test('readPort and writePort operate on simulated ports', () => {
+  writePort(0x10, 123);
+  assert.strictEqual(readPort(0x10), 123);
+});
+
+test('interruptController registers and triggers handlers', () => {
+  let called = false;
+  interruptController.register('IRQ1', () => { called = true; });
+  interruptController.trigger('IRQ1');
+  assert.ok(called);
+  interruptController.clear('IRQ1');
+});
+
+test('timer.setTimeout executes callback', async () => {
+  let fired = false;
+  const id = timer.setTimeout(() => { fired = true; }, 10);
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert.ok(fired);
+  timer.clearTimeout(id);
+});
+
+test('powerManagement tracks power state', () => {
+  powerManagement.shutdown();
+  assert.strictEqual(powerManagement.getState(), 'off');
+  powerManagement.reboot();
+  assert.strictEqual(powerManagement.getState(), 'rebooting');
+});


### PR DESCRIPTION
## Summary
- add HAL package with port I/O, interrupt controller, timer and power management APIs
- document HAL interfaces for kernel modules
- test simulated hardware operations using Node timers and mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892be5894ac832990f97d85c2d05ae3