### PR TITLE
Add kernel process scheduler and synchronization primitives

### DIFF
--- a/kernel/process.js
+++ b/kernel/process.js
@@ -1,0 +1,39 @@
+export class Process {
+  constructor(pid, priority = 0) {
+    this.pid = pid;
+    this.priority = priority;
+    this.state = 'ready';
+    this.threads = [];
+    this.context = {};
+  }
+
+  addThread(thread) {
+    this.threads.push(thread);
+  }
+}
+
+export class ProcessTable {
+  constructor() {
+    this.processes = new Map();
+    this.nextPid = 1;
+  }
+
+  createProcess(priority = 0) {
+    const pid = this.nextPid++;
+    const process = new Process(pid, priority);
+    this.processes.set(pid, process);
+    return process;
+  }
+
+  removeProcess(pid) {
+    this.processes.delete(pid);
+  }
+
+  getProcess(pid) {
+    return this.processes.get(pid);
+  }
+
+  all() {
+    return Array.from(this.processes.values());
+  }
+}

--- a/kernel/scheduler.js
+++ b/kernel/scheduler.js
@@ -1,0 +1,113 @@
+import { ProcessTable } from './process.js';
+
+export class Scheduler {
+  constructor() {
+    this.table = new ProcessTable();
+    this.readyQueue = [];
+    this.current = null;
+  }
+
+  createProcess(priority = 0) {
+    const proc = this.table.createProcess(priority);
+    this.enqueue(proc);
+    return proc;
+  }
+
+  enqueue(proc) {
+    proc.state = 'ready';
+    this.readyQueue.push(proc);
+    this.readyQueue.sort((a, b) => b.priority - a.priority);
+  }
+
+  schedule() {
+    if (this.current && this.current.state === 'running') {
+      this.enqueue(this.current);
+    }
+    const next = this.readyQueue.shift();
+    if (next) {
+      this.contextSwitch(next);
+    } else {
+      this.current = null;
+    }
+    return this.current;
+  }
+
+  contextSwitch(proc) {
+    if (this.current) {
+      this.current.state = 'ready';
+    }
+    this.current = proc;
+    proc.state = 'running';
+  }
+}
+
+export class Mutex {
+  constructor() {
+    this.locked = false;
+    this.waiters = [];
+  }
+
+  lock() {
+    return new Promise(resolve => {
+      if (!this.locked) {
+        this.locked = true;
+        resolve();
+      } else {
+        this.waiters.push(resolve);
+      }
+    });
+  }
+
+  unlock() {
+    if (this.waiters.length > 0) {
+      const next = this.waiters.shift();
+      next();
+    } else {
+      this.locked = false;
+    }
+  }
+}
+
+export class Semaphore {
+  constructor(count = 1) {
+    this.count = count;
+    this.waiters = [];
+  }
+
+  wait() {
+    return new Promise(resolve => {
+      if (this.count > 0) {
+        this.count--;
+        resolve();
+      } else {
+        this.waiters.push(resolve);
+      }
+    });
+  }
+
+  signal() {
+    if (this.waiters.length > 0) {
+      const next = this.waiters.shift();
+      next();
+    } else {
+      this.count++;
+    }
+  }
+}
+
+export class Spinlock {
+  constructor() {
+    this.locked = false;
+  }
+
+  async lock() {
+    while (this.locked) {
+      await new Promise(r => setImmediate(r));
+    }
+    this.locked = true;
+  }
+
+  unlock() {
+    this.locked = false;
+  }
+}

--- a/kernel/thread.js
+++ b/kernel/thread.js
@@ -1,0 +1,19 @@
+let nextTid = 1;
+
+export class Thread {
+  constructor(entry) {
+    this.tid = nextTid++;
+    this.entry = entry;
+    this.state = 'ready';
+    this.context = {};
+  }
+
+  async start(...args) {
+    this.state = 'running';
+    try {
+      return await this.entry(...args);
+    } finally {
+      this.state = 'terminated';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Process and ProcessTable modules
- introduce Thread abstraction and basic Scheduler with context switching
- include mutex, semaphore, and spinlock synchronization primitives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892cd12c85483299eb7dec134822f33