### PR TITLE
Add simulated IO manager with IRQ and driver stubs

### DIFF
--- a/kernel/io/deviceManager.js
+++ b/kernel/io/deviceManager.js
@@ -1,0 +1,38 @@
+import irqController from './irq.js';
+
+export class DeviceManager {
+  constructor() {
+    this.drivers = new Map();
+  }
+
+  registerDriver(driver) {
+    this.drivers.set(driver.name, driver);
+    if (driver.irq) {
+      irqController.register(driver.irq, data => {
+        if (typeof driver.handleIRQ === 'function') {
+          driver.handleIRQ(data);
+        }
+      });
+    }
+  }
+
+  sendRequest(name, request) {
+    const driver = this.drivers.get(name);
+    if (!driver || typeof driver.handleRequest !== 'function') {
+      throw new Error(`No driver registered for ${name}`);
+    }
+    return driver.handleRequest(request);
+  }
+
+  reset() {
+    for (const driver of this.drivers.values()) {
+      if (driver.irq) {
+        irqController.clear(driver.irq);
+      }
+    }
+    this.drivers.clear();
+  }
+}
+
+export const deviceManager = new DeviceManager();
+export default deviceManager;

--- a/kernel/io/drivers/base.js
+++ b/kernel/io/drivers/base.js
@@ -1,0 +1,18 @@
+export class Driver {
+  constructor(name, irq) {
+    this.name = name;
+    this.irq = irq;
+  }
+
+  // Handle a generic request for the device
+  handleRequest(_request) {
+    // To be implemented by subclasses
+  }
+
+  // Handle an interrupt request
+  handleIRQ(_data) {
+    // To be implemented by subclasses
+  }
+}
+
+export default Driver;

--- a/kernel/io/drivers/display.js
+++ b/kernel/io/drivers/display.js
@@ -1,0 +1,21 @@
+import Driver from './base.js';
+
+export class DisplayDriver extends Driver {
+  constructor() {
+    super('display', 'IRQ_DISPLAY');
+    this.requests = [];
+    this.irqCount = 0;
+  }
+
+  handleRequest(request) {
+    this.requests.push(request);
+    return `display:${request}`;
+  }
+
+  handleIRQ(data) {
+    this.irqCount++;
+    this.lastIRQ = data;
+  }
+}
+
+export default DisplayDriver;

--- a/kernel/io/drivers/input.js
+++ b/kernel/io/drivers/input.js
@@ -1,0 +1,21 @@
+import Driver from './base.js';
+
+export class InputDriver extends Driver {
+  constructor() {
+    super('input', 'IRQ_INPUT');
+    this.requests = [];
+    this.irqCount = 0;
+  }
+
+  handleRequest(request) {
+    this.requests.push(request);
+    return `input:${request}`;
+  }
+
+  handleIRQ(data) {
+    this.irqCount++;
+    this.lastIRQ = data;
+  }
+}
+
+export default InputDriver;

--- a/kernel/io/drivers/network.js
+++ b/kernel/io/drivers/network.js
@@ -1,0 +1,21 @@
+import Driver from './base.js';
+
+export class NetworkDriver extends Driver {
+  constructor() {
+    super('network', 'IRQ_NETWORK');
+    this.requests = [];
+    this.irqCount = 0;
+  }
+
+  handleRequest(request) {
+    this.requests.push(request);
+    return `network:${request}`;
+  }
+
+  handleIRQ(data) {
+    this.irqCount++;
+    this.lastIRQ = data;
+  }
+}
+
+export default NetworkDriver;

--- a/kernel/io/drivers/storage.js
+++ b/kernel/io/drivers/storage.js
@@ -1,0 +1,21 @@
+import Driver from './base.js';
+
+export class StorageDriver extends Driver {
+  constructor() {
+    super('storage', 'IRQ_STORAGE');
+    this.requests = [];
+    this.irqCount = 0;
+  }
+
+  handleRequest(request) {
+    this.requests.push(request);
+    return `storage:${request}`;
+  }
+
+  handleIRQ(data) {
+    this.irqCount++;
+    this.lastIRQ = data;
+  }
+}
+
+export default StorageDriver;

--- a/kernel/io/irq.js
+++ b/kernel/io/irq.js
@@ -1,0 +1,26 @@
+export class IRQController {
+  constructor() {
+    this.handlers = new Map();
+  }
+
+  register(irq, handler) {
+    if (!this.handlers.has(irq)) {
+      this.handlers.set(irq, []);
+    }
+    this.handlers.get(irq).push(handler);
+  }
+
+  trigger(irq, ...args) {
+    const list = this.handlers.get(irq) || [];
+    for (const handler of list) {
+      handler(...args);
+    }
+  }
+
+  clear(irq) {
+    this.handlers.delete(irq);
+  }
+}
+
+export const irqController = new IRQController();
+export default irqController;

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import deviceManager from '../kernel/io/deviceManager.js';
+import { irqController } from '../kernel/io/irq.js';
+import StorageDriver from '../kernel/io/drivers/storage.js';
+import NetworkDriver from '../kernel/io/drivers/network.js';
+import DisplayDriver from '../kernel/io/drivers/display.js';
+import InputDriver from '../kernel/io/drivers/input.js';
+
+function setup() {
+  deviceManager.reset();
+}
+
+test('device manager dispatches requests to appropriate drivers', () => {
+  setup();
+  const storage = new StorageDriver();
+  const network = new NetworkDriver();
+  const display = new DisplayDriver();
+  const input = new InputDriver();
+  deviceManager.registerDriver(storage);
+  deviceManager.registerDriver(network);
+  deviceManager.registerDriver(display);
+  deviceManager.registerDriver(input);
+  assert.strictEqual(deviceManager.sendRequest('storage', 'read'), 'storage:read');
+  assert.strictEqual(deviceManager.sendRequest('network', 'send'), 'network:send');
+  assert.strictEqual(deviceManager.sendRequest('display', 'render'), 'display:render');
+  assert.strictEqual(deviceManager.sendRequest('input', 'poll'), 'input:poll');
+});
+
+
+test('irq triggers driver handlers', () => {
+  setup();
+  const network = new NetworkDriver();
+  deviceManager.registerDriver(network);
+  irqController.trigger('IRQ_NETWORK', 'packet');
+  assert.strictEqual(network.irqCount, 1);
+  assert.strictEqual(network.lastIRQ, 'packet');
+});


### PR DESCRIPTION
## Summary
- Add IRQ controller and unified device manager for kernel IO
- Implement base driver interface with storage, network, display and input stubs
- Verify device requests and IRQ handling with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892d34989b483299c2697ce5bc9dbcd