### PR TITLE
Add kernel object manager with ACL and handle tracking

### DIFF
--- a/kernel/executive/objectManager.js
+++ b/kernel/executive/objectManager.js
@@ -1,0 +1,123 @@
+class Namespace {
+  constructor() {
+    this.objects = new Map(); // name -> entry
+    this.children = new Map(); // name -> Namespace
+  }
+}
+
+export class ObjectManager {
+  constructor() {
+    this.root = new Namespace();
+    this.handleTable = new Map(); // handle -> { entry, rights }
+    this.nextHandle = 1;
+  }
+
+  _split(path) {
+    return path.split(/\\+/).filter(Boolean);
+  }
+
+  _resolve(path, create = false) {
+    const parts = this._split(path);
+    let ns = this.root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!ns.children.has(part)) {
+        if (!create) {
+          throw new Error('Namespace not found');
+        }
+        ns.children.set(part, new Namespace());
+      }
+      ns = ns.children.get(part);
+    }
+    const name = parts[parts.length - 1];
+    return { ns, name };
+  }
+
+  _getEntry(path) {
+    const { ns, name } = this._resolve(path, false);
+    const entry = ns.objects.get(name);
+    if (!entry) {
+      throw new Error('Object not found');
+    }
+    return entry;
+  }
+
+  _getRights(entry, sid) {
+    if (entry.acl.has(sid)) {
+      return entry.acl.get(sid);
+    }
+    return entry.rights;
+  }
+
+  registerObject(path, object, options = {}) {
+    const { rights = ['read', 'write'], acl = {} } = options;
+    const { ns, name } = this._resolve(path, true);
+    if (ns.objects.has(name)) {
+      throw new Error('Object already exists');
+    }
+    const entry = {
+      object,
+      rights: new Set(rights),
+      acl: new Map(),
+      refCount: 0
+    };
+    if (acl instanceof Map) {
+      for (const [sid, rightsArr] of acl.entries()) {
+        entry.acl.set(sid, new Set(rightsArr));
+      }
+    } else {
+      for (const sid of Object.keys(acl)) {
+        entry.acl.set(sid, new Set(acl[sid]));
+      }
+    }
+    ns.objects.set(name, entry);
+  }
+
+  openHandle(path, desiredRights = ['read'], sid = 'system') {
+    const entry = this._getEntry(path);
+    const available = this._getRights(entry, sid);
+    for (const r of desiredRights) {
+      if (!available.has(r)) {
+        throw new Error('Access denied');
+      }
+    }
+    const handle = this.nextHandle++;
+    this.handleTable.set(handle, {
+      entry,
+      rights: new Set(desiredRights)
+    });
+    entry.refCount++;
+    return handle;
+  }
+
+  getObject(handle, requiredRights = []) {
+    const h = this.handleTable.get(handle);
+    if (!h) {
+      throw new Error('Invalid handle');
+    }
+    for (const r of requiredRights) {
+      if (!h.rights.has(r)) {
+        throw new Error('Access denied');
+      }
+    }
+    return h.entry.object;
+  }
+
+  closeHandle(handle) {
+    const h = this.handleTable.get(handle);
+    if (!h) return;
+    this.handleTable.delete(handle);
+    h.entry.refCount--;
+  }
+
+  queryObject(path) {
+    const entry = this._getEntry(path);
+    return {
+      refCount: entry.refCount,
+      rights: Array.from(entry.rights),
+      acl: Array.from(entry.acl.entries()).map(([sid, rights]) => [sid, Array.from(rights)])
+    };
+  }
+}
+
+export const objectManager = new ObjectManager();

--- a/test/objectManager.test.js
+++ b/test/objectManager.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { ObjectManager } from '../kernel/executive/objectManager.js';
+
+// Test handle allocation and reference counting
+
+test('object manager allocates handles and tracks references', () => {
+  const om = new ObjectManager();
+  om.registerObject('\\obj', {});
+  const handle = om.openHandle('\\obj');
+  assert.strictEqual(typeof handle, 'number');
+  assert.strictEqual(om.queryObject('\\obj').refCount, 1);
+  om.closeHandle(handle);
+  assert.strictEqual(om.queryObject('\\obj').refCount, 0);
+});
+
+// Test rights and ACL enforcement
+
+test('object manager enforces rights and ACL', () => {
+  const om = new ObjectManager();
+  om.registerObject('\\secret', {}, { acl: { user: ['read'] } });
+  assert.throws(() => om.openHandle('\\secret', ['write'], 'user'));
+  const handle = om.openHandle('\\secret', ['read'], 'user');
+  assert.ok(handle);
+});
+
+// Test namespaces
+
+test('object manager supports namespaces', () => {
+  const om = new ObjectManager();
+  om.registerObject('\\dir\\obj', {});
+  const handle = om.openHandle('\\dir\\obj');
+  assert.ok(handle);
+  const info = om.queryObject('\\dir\\obj');
+  assert.strictEqual(info.refCount, 1);
+});


### PR DESCRIPTION
## Summary
- add executive/objectManager.js to provide namespace-aware kernel object manager
- implement handle allocation with reference counting and rights/ACL enforcement
- expose APIs to register, open, close, and query objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892d55c9c908329b05745e710cb7aea