### PR TITLE
Add basic VFS with FAT/NTFS and cache manager

### DIFF
--- a/kernel/executive/fs/cacheManager.js
+++ b/kernel/executive/fs/cacheManager.js
@@ -1,0 +1,64 @@
+export class CacheManager {
+  constructor(maxEntries = 100) {
+    this.maxEntries = maxEntries;
+    this.cache = new Map(); // key -> { data, metadata }
+  }
+
+  _key(fs, path) {
+    return `${fs.volumeId}:${path}`;
+  }
+
+  read(fs, path, fetch) {
+    const key = this._key(fs, path);
+    const entry = this.cache.get(key);
+    if (entry && entry.data !== null) {
+      return entry.data;
+    }
+    const data = fetch();
+    const meta = {
+      size: data.length,
+      created: entry?.metadata?.created || new Date(),
+      modified: new Date()
+    };
+    this.cache.set(key, { data, metadata: meta });
+    this._evict();
+    return data;
+  }
+
+  write(fs, path, data, commit) {
+    const key = this._key(fs, path);
+    commit(data);
+    const meta = {
+      size: data.length,
+      created: new Date(),
+      modified: new Date()
+    };
+    this.cache.set(key, { data, metadata: meta });
+    this._evict();
+  }
+
+  getMetadata(fs, path, fetchMeta) {
+    const key = this._key(fs, path);
+    const entry = this.cache.get(key);
+    if (entry && entry.metadata) {
+      return entry.metadata;
+    }
+    const meta = fetchMeta();
+    this.cache.set(key, { data: null, metadata: meta });
+    this._evict();
+    return meta;
+  }
+
+  invalidate(fs, path) {
+    this.cache.delete(this._key(fs, path));
+  }
+
+  _evict() {
+    while (this.cache.size > this.maxEntries) {
+      const firstKey = this.cache.keys().next().value;
+      this.cache.delete(firstKey);
+    }
+  }
+}
+
+export const cacheManager = new CacheManager();

--- a/kernel/executive/fs/fat.js
+++ b/kernel/executive/fs/fat.js
@@ -1,0 +1,54 @@
+import { cacheManager } from './cacheManager.js';
+
+export class FATFileSystem {
+  constructor() {
+    this.volumeId = `fat-${Math.random().toString(16).slice(2)}`;
+    this.mounted = false;
+    this.files = new Map(); // normalizedPath -> { data: Buffer, metadata }
+  }
+
+  mount() {
+    this.mounted = true;
+  }
+
+  _normalizePath(path) {
+    return path.replace(/\\/g, '/').toUpperCase();
+  }
+
+  readFile(path) {
+    if (!this.mounted) throw new Error('Filesystem not mounted');
+    return cacheManager.read(this, path, () => {
+      const key = this._normalizePath(path);
+      const file = this.files.get(key);
+      if (!file) throw new Error('File not found');
+      return file.data;
+    });
+  }
+
+  writeFile(path, data) {
+    if (!this.mounted) throw new Error('Filesystem not mounted');
+    cacheManager.write(this, path, Buffer.isBuffer(data) ? data : Buffer.from(data), d => {
+      const key = this._normalizePath(path);
+      const now = new Date();
+      const file = this.files.get(key) || { metadata: { created: now } };
+      file.data = d;
+      file.metadata.size = d.length;
+      file.metadata.modified = now;
+      this.files.set(key, file);
+    });
+  }
+
+  getMetadata(path) {
+    if (!this.mounted) throw new Error('Filesystem not mounted');
+    return cacheManager.getMetadata(this, path, () => {
+      const key = this._normalizePath(path);
+      const file = this.files.get(key);
+      if (!file) throw new Error('File not found');
+      return file.metadata;
+    });
+  }
+
+  listFiles() {
+    return Array.from(this.files.keys());
+  }
+}

--- a/kernel/executive/fs/ntfs.js
+++ b/kernel/executive/fs/ntfs.js
@@ -1,0 +1,54 @@
+import { cacheManager } from './cacheManager.js';
+
+export class NTFSFileSystem {
+  constructor() {
+    this.volumeId = `ntfs-${Math.random().toString(16).slice(2)}`;
+    this.mounted = false;
+    this.files = new Map(); // normalizedPath -> { data: Buffer, metadata }
+  }
+
+  mount() {
+    this.mounted = true;
+  }
+
+  _normalizePath(path) {
+    return path.replace(/\\/g, '/').toLowerCase();
+  }
+
+  readFile(path) {
+    if (!this.mounted) throw new Error('Filesystem not mounted');
+    return cacheManager.read(this, path, () => {
+      const key = this._normalizePath(path);
+      const file = this.files.get(key);
+      if (!file) throw new Error('File not found');
+      return file.data;
+    });
+  }
+
+  writeFile(path, data) {
+    if (!this.mounted) throw new Error('Filesystem not mounted');
+    cacheManager.write(this, path, Buffer.isBuffer(data) ? data : Buffer.from(data), d => {
+      const key = this._normalizePath(path);
+      const now = new Date();
+      const file = this.files.get(key) || { metadata: { created: now } };
+      file.data = d;
+      file.metadata.size = d.length;
+      file.metadata.modified = now;
+      this.files.set(key, file);
+    });
+  }
+
+  getMetadata(path) {
+    if (!this.mounted) throw new Error('Filesystem not mounted');
+    return cacheManager.getMetadata(this, path, () => {
+      const key = this._normalizePath(path);
+      const file = this.files.get(key);
+      if (!file) throw new Error('File not found');
+      return file.metadata;
+    });
+  }
+
+  listFiles() {
+    return Array.from(this.files.keys());
+  }
+}

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { FATFileSystem } from '../kernel/executive/fs/fat.js';
+import { NTFSFileSystem } from '../kernel/executive/fs/ntfs.js';
+import { cacheManager } from '../kernel/executive/fs/cacheManager.js';
+
+function exercise(fs) {
+  fs.mount();
+  fs.writeFile('/foo.txt', Buffer.from('hello'));
+  assert.strictEqual(fs.readFile('/foo.txt').toString(), 'hello');
+  const meta = fs.getMetadata('/foo.txt');
+  assert.strictEqual(meta.size, 5);
+}
+
+test('FAT and NTFS basic operations', () => {
+  exercise(new FATFileSystem());
+  exercise(new NTFSFileSystem());
+});
+
+test('cache manager buffers file reads', () => {
+  const fs = new FATFileSystem();
+  fs.mount();
+  fs.writeFile('/cache.txt', Buffer.from('cached'));
+  // Change underlying storage without invalidating cache
+  const key = fs._normalizePath('/cache.txt');
+  fs.files.get(key).data = Buffer.from('modified');
+  // Should return cached data
+  assert.strictEqual(fs.readFile('/cache.txt').toString(), 'cached');
+  // After invalidation, should reflect modified data
+  cacheManager.invalidate(fs, '/cache.txt');
+  assert.strictEqual(fs.readFile('/cache.txt').toString(), 'modified');
+});


### PR DESCRIPTION
## Summary
- add cache manager for buffered file IO
- implement in-memory FAT and NTFS filesystems with unified API
- test filesystem operations and caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892dd28a5888329829467840d3ba217