### PR TITLE
Add simulated network stack

### DIFF
--- a/kernel/executive/net/ip.js
+++ b/kernel/executive/net/ip.js
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'events';
+
+// Simple network interface simulation and packet router
+// Each interface has an IP address and can send/receive packets
+
+export class NetworkInterface extends EventEmitter {
+  constructor(address) {
+    super();
+    this.address = address;
+  }
+
+  send(dest, protocol, payload) {
+    sendPacket(this.address, dest, protocol, payload);
+  }
+}
+
+const interfaces = new Map();
+
+export function registerInterface(iface) {
+  interfaces.set(iface.address, iface);
+}
+
+export function unregisterInterface(address) {
+  interfaces.delete(address);
+}
+
+export function sendPacket(src, dest, protocol, payload) {
+  const iface = interfaces.get(dest);
+  if (iface) {
+    iface.emit('packet', { src, dest, protocol, payload });
+  }
+}
+
+// Helper used in tests to reset router state
+export function _clear() {
+  interfaces.clear();
+}

--- a/kernel/executive/net/socket.js
+++ b/kernel/executive/net/socket.js
@@ -1,0 +1,69 @@
+import { createSocket as createUDPSocket } from './udp.js';
+import { createServer as createTCPServer, connect as tcpConnect } from './tcp.js';
+
+export class Socket {
+  constructor(type, adapter) {
+    this.type = type;
+    this.adapter = adapter;
+    this.port = null;
+    this.impl = null;
+    this.server = null;
+  }
+
+  bind(port) {
+    this.port = port;
+    if (this.type === 'udp') {
+      this.impl = createUDPSocket(this.adapter, port);
+    }
+  }
+
+  listen(handler) {
+    if (this.type !== 'tcp') {
+      throw new Error('listen only valid for TCP sockets');
+    }
+    this.server = createTCPServer(this.adapter, this.port, (sock) => {
+      handler(new WrappedTCPSocket(sock));
+    });
+  }
+
+  connect(addr, port) {
+    if (this.type !== 'tcp') {
+      throw new Error('connect only valid for TCP sockets');
+    }
+    this.impl = tcpConnect(this.adapter, addr, port);
+    return new WrappedTCPSocket(this.impl);
+  }
+
+  send(...args) {
+    if (this.type === 'udp') {
+      const [addr, port, data] = args;
+      this.impl.send(addr, port, data);
+    } else if (this.type === 'tcp') {
+      const [data] = args;
+      this.impl.send(data);
+    }
+  }
+
+  on(event, handler) {
+    this.impl.on(event, handler);
+  }
+
+  close() {
+    this.impl?.close?.();
+    this.server?.close?.();
+  }
+}
+
+class WrappedTCPSocket {
+  constructor(sock) {
+    this.sock = sock;
+  }
+  send(data) { this.sock.send(data); }
+  on(ev, h) { this.sock.on(ev, h); }
+  close() { this.sock.close(); }
+}
+
+export default function socket(options) {
+  const { type, adapter } = options;
+  return new Socket(type, adapter);
+}

--- a/kernel/executive/net/tcp.js
+++ b/kernel/executive/net/tcp.js
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events';
+import { sendPacket } from './ip.js';
+
+const servers = new Map(); // key: address:port -> handler
+
+function key(addr, port) {
+  return `${addr}:${port}`;
+}
+
+class TCPSocket extends EventEmitter {
+  constructor(adapter, localPort, remoteAddr, remotePort) {
+    super();
+    this.adapter = adapter;
+    this.localPort = localPort;
+    this.remoteAddr = remoteAddr;
+    this.remotePort = remotePort;
+    this.connected = false;
+    this._onPacket = (pkt) => {
+      if (pkt.protocol !== 'TCP') return;
+      const p = pkt.payload;
+      if (p.destPort !== this.localPort) return;
+      if (pkt.src !== this.remoteAddr) return;
+      if (p.type === 'ACCEPT') {
+        this.connected = true;
+        queueMicrotask(() => this.emit('connect'));
+      } else if (p.type === 'DATA') {
+        queueMicrotask(() => this.emit('data', p.data));
+      }
+    };
+    adapter.on('packet', this._onPacket);
+  }
+
+  send(data) {
+    if (!this.connected) return;
+    sendPacket(this.adapter.address, this.remoteAddr, 'TCP', {
+      type: 'DATA',
+      srcPort: this.localPort,
+      destPort: this.remotePort,
+      data
+    });
+  }
+
+  close() {
+    this.adapter.off('packet', this._onPacket);
+  }
+}
+
+export function createServer(adapter, port, onConnection) {
+  const serverKey = key(adapter.address, port);
+  if (servers.has(serverKey)) {
+    throw new Error('Port already in use');
+  }
+  const handler = (pkt) => {
+    if (pkt.protocol !== 'TCP') return;
+    const p = pkt.payload;
+    if (p.destPort !== port || p.type !== 'CONNECT') return;
+    const sock = new TCPSocket(adapter, port, pkt.src, p.srcPort);
+    sock.connected = true;
+    sendPacket(adapter.address, pkt.src, 'TCP', {
+      type: 'ACCEPT',
+      srcPort: port,
+      destPort: p.srcPort
+    });
+    onConnection(sock);
+  };
+  adapter.on('packet', handler);
+  servers.set(serverKey, handler);
+  return {
+    close() {
+      adapter.off('packet', handler);
+      servers.delete(serverKey);
+    }
+  };
+}
+
+let nextPort = 40000;
+function allocPort() {
+  return nextPort++;
+}
+
+export function connect(adapter, destAddr, destPort) {
+  const localPort = allocPort();
+  const sock = new TCPSocket(adapter, localPort, destAddr, destPort);
+  sendPacket(adapter.address, destAddr, 'TCP', {
+    type: 'CONNECT',
+    srcPort: localPort,
+    destPort
+  });
+  return sock;
+}
+
+export { TCPSocket };

--- a/kernel/executive/net/udp.js
+++ b/kernel/executive/net/udp.js
@@ -1,0 +1,32 @@
+import { EventEmitter } from 'events';
+import { sendPacket } from './ip.js';
+
+export class UDPSocket extends EventEmitter {
+  constructor(adapter, port) {
+    super();
+    this.adapter = adapter;
+    this.port = port;
+    this._onPacket = (pkt) => {
+      if (pkt.protocol === 'UDP' && pkt.payload.destPort === this.port) {
+        this.emit('message', pkt.payload.data, pkt.src, pkt.payload.srcPort);
+      }
+    };
+    adapter.on('packet', this._onPacket);
+  }
+
+  send(destAddr, destPort, data) {
+    sendPacket(this.adapter.address, destAddr, 'UDP', {
+      srcPort: this.port,
+      destPort,
+      data
+    });
+  }
+
+  close() {
+    this.adapter.off('packet', this._onPacket);
+  }
+}
+
+export function createSocket(adapter, port) {
+  return new UDPSocket(adapter, port);
+}

--- a/test/net.test.js
+++ b/test/net.test.js
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { NetworkInterface, registerInterface, _clear } from '../kernel/executive/net/ip.js';
+import { createSocket as createUDPSocket } from '../kernel/executive/net/udp.js';
+import { createServer, connect } from '../kernel/executive/net/tcp.js';
+import socket from '../kernel/executive/net/socket.js';
+
+function setupAdapters() {
+  _clear();
+  const a = new NetworkInterface('10.0.0.1');
+  const b = new NetworkInterface('10.0.0.2');
+  registerInterface(a);
+  registerInterface(b);
+  return { a, b };
+}
+
+test('UDP packets route between interfaces', async () => {
+  const { a, b } = setupAdapters();
+  const sockB = createUDPSocket(b, 5000);
+  const sockA = createUDPSocket(a, 4000);
+
+  const received = new Promise((resolve) => {
+    sockB.on('message', (data, src) => {
+      assert.strictEqual(src, '10.0.0.1');
+      assert.strictEqual(data.toString(), 'hello');
+      resolve();
+    });
+  });
+
+  sockA.send('10.0.0.2', 5000, Buffer.from('hello'));
+  await received;
+});
+
+test('TCP connection and data transfer', async () => {
+  const { a, b } = setupAdapters();
+  let serverConn;
+  const server = createServer(b, 8080, (sock) => {
+    serverConn = sock;
+    sock.on('data', (d) => {
+      assert.strictEqual(d.toString(), 'ping');
+      sock.send('pong');
+    });
+  });
+
+  const client = connect(a, '10.0.0.2', 8080);
+  await new Promise((res) => client.on('connect', res));
+
+  let response;
+  client.on('data', (d) => { response = d.toString(); });
+  client.send('ping');
+  await new Promise((r) => setTimeout(r, 10));
+  assert.strictEqual(response, 'pong');
+  client.close();
+  serverConn.close();
+  server.close();
+});
+
+test('socket.js provides unified API', async () => {
+  const { a, b } = setupAdapters();
+  const serverSock = socket({ type: 'tcp', adapter: b });
+  serverSock.bind(9090);
+  serverSock.listen((conn) => {
+    conn.on('data', (d) => conn.send(d));
+  });
+
+  const clientSock = socket({ type: 'tcp', adapter: a });
+  const conn = clientSock.connect('10.0.0.2', 9090);
+  await new Promise((r) => conn.on('connect', r));
+  let echo;
+  conn.on('data', (d) => { echo = d.toString(); });
+  conn.send('echo');
+  await new Promise((r) => setTimeout(r, 10));
+  assert.strictEqual(echo, 'echo');
+  conn.close();
+  serverSock.close();
+});


### PR DESCRIPTION
## Summary
- add simple IP router and interface registry
- implement UDP and TCP sockets with basic send/receive and connection handling
- provide Winsock-like socket wrapper and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892e09bbb108329ab8192e457aa7b9c