### PR TITLE
feat(graphics): add surface and device context

### DIFF
--- a/kernel/executive/graphics/deviceContext.js
+++ b/kernel/executive/graphics/deviceContext.js
@@ -1,0 +1,248 @@
+import { Surface } from './surface.js';
+
+function colorToRGBA(color) {
+  if (Array.isArray(color)) return color;
+  if (typeof color === 'string') {
+    if (color.startsWith('#')) {
+      let hex = color.slice(1);
+      if (hex.length === 3) {
+        hex = hex.split('').map(c => c + c).join('');
+      }
+      if (hex.length === 6) hex += 'ff';
+      const r = parseInt(hex.slice(0, 2), 16);
+      const g = parseInt(hex.slice(2, 4), 16);
+      const b = parseInt(hex.slice(4, 6), 16);
+      const a = parseInt(hex.slice(6, 8), 16);
+      return [r, g, b, a];
+    }
+  }
+  return [0, 0, 0, 255];
+}
+
+export class DeviceContext {
+  constructor(surface) {
+    if (!(surface instanceof Surface)) throw new Error('DC requires Surface');
+    this.surface = surface;
+    if (surface.gl) {
+      this._initGL();
+    }
+  }
+
+  _initGL() {
+    const gl = this.surface.gl;
+    // Simple shader for colored primitives
+    const vert = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vert, `
+      attribute vec2 aPos;
+      uniform vec2 uResolution;
+      void main() {
+        vec2 zeroToOne = aPos / uResolution;
+        vec2 clip = zeroToOne * 2.0 - 1.0;
+        gl_Position = vec4(clip * vec2(1, -1), 0, 1);
+      }
+    `);
+    gl.compileShader(vert);
+
+    const frag = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(frag, `
+      precision mediump float;
+      uniform vec4 uColor;
+      void main() { gl_FragColor = uColor; }
+    `);
+    gl.compileShader(frag);
+
+    const prog = gl.createProgram();
+    gl.attachShader(prog, vert);
+    gl.attachShader(prog, frag);
+    gl.linkProgram(prog);
+
+    this.glProg = prog;
+    this.aPos = gl.getAttribLocation(prog, 'aPos');
+    this.uResolution = gl.getUniformLocation(prog, 'uResolution');
+    this.uColor = gl.getUniformLocation(prog, 'uColor');
+    this.buf = gl.createBuffer();
+  }
+
+  line(x1, y1, x2, y2, color = '#000') {
+    const rgba = colorToRGBA(color);
+    if (this.surface.ctx) {
+      const ctx = this.surface.ctx;
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(x1 + 0.5, y1 + 0.5);
+      ctx.lineTo(x2 + 0.5, y2 + 0.5);
+      ctx.stroke();
+    } else if (this.surface.gl) {
+      const gl = this.surface.gl;
+      gl.useProgram(this.glProg);
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.buf);
+      const verts = new Float32Array([x1, y1, x2, y2]);
+      gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STREAM_DRAW);
+      gl.enableVertexAttribArray(this.aPos);
+      gl.vertexAttribPointer(this.aPos, 2, gl.FLOAT, false, 0, 0);
+      gl.uniform2f(this.uResolution, this.surface.width, this.surface.height);
+      gl.uniform4f(this.uColor, rgba[0]/255, rgba[1]/255, rgba[2]/255, rgba[3]/255);
+      gl.drawArrays(gl.LINES, 0, 2);
+    } else {
+      // software backend
+      this._lineSoftware(x1, y1, x2, y2, rgba);
+    }
+  }
+
+  rect(x, y, w, h, color = '#000', fill = false) {
+    const rgba = colorToRGBA(color);
+    if (this.surface.ctx) {
+      const ctx = this.surface.ctx;
+      ctx.strokeStyle = color;
+      ctx.fillStyle = color;
+      if (fill) ctx.fillRect(x, y, w, h);
+      else ctx.strokeRect(x, y, w, h);
+    } else if (this.surface.gl) {
+      if (fill) {
+        // Draw two triangles
+        const gl = this.surface.gl;
+        gl.useProgram(this.glProg);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.buf);
+        const verts = new Float32Array([
+          x, y, x + w, y, x, y + h, x + w, y + h
+        ]);
+        gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STREAM_DRAW);
+        gl.enableVertexAttribArray(this.aPos);
+        gl.vertexAttribPointer(this.aPos, 2, gl.FLOAT, false, 0, 0);
+        gl.uniform2f(this.uResolution, this.surface.width, this.surface.height);
+        gl.uniform4f(this.uColor, rgba[0]/255, rgba[1]/255, rgba[2]/255, rgba[3]/255);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+      } else {
+        const gl = this.surface.gl;
+        gl.useProgram(this.glProg);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.buf);
+        const verts = new Float32Array([
+          x, y, x + w, y, x + w, y + h, x, y + h
+        ]);
+        gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STREAM_DRAW);
+        gl.enableVertexAttribArray(this.aPos);
+        gl.vertexAttribPointer(this.aPos, 2, gl.FLOAT, false, 0, 0);
+        gl.uniform2f(this.uResolution, this.surface.width, this.surface.height);
+        gl.uniform4f(this.uColor, rgba[0]/255, rgba[1]/255, rgba[2]/255, rgba[3]/255);
+        gl.drawArrays(gl.LINE_LOOP, 0, 4);
+      }
+    } else {
+      this._rectSoftware(x, y, w, h, rgba, fill);
+    }
+  }
+
+  blit(srcSurface, sx = 0, sy = 0, sw = srcSurface.width, sh = srcSurface.height, dx = 0, dy = 0) {
+    if (this.surface.ctx && srcSurface.canvas) {
+      this.surface.ctx.drawImage(srcSurface.canvas, sx, sy, sw, sh, dx, dy, sw, sh);
+    } else if (this.surface.gl) {
+      // Simple WebGL blit using tex + quad
+      const gl = this.surface.gl;
+      const tex = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      if (srcSurface.gl) {
+        gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sx, sy, sw, sh, 0);
+      } else if (srcSurface.ctx) {
+        const data = srcSurface.ctx.getImageData(sx, sy, sw, sh).data;
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sw, sh, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
+      } else {
+        const data = new Uint8Array(srcSurface.buffer.buffer, srcSurface._index(sx, sy), sw * sh * 4);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sw, sh, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
+      }
+
+      const vert = gl.createShader(gl.VERTEX_SHADER);
+      gl.shaderSource(vert, `
+        attribute vec2 aPos;
+        attribute vec2 aTex;
+        uniform vec2 uResolution;
+        varying vec2 vTex;
+        void main() {
+          vec2 zeroToOne = aPos / uResolution;
+          vec2 clip = zeroToOne * 2.0 - 1.0;
+          gl_Position = vec4(clip * vec2(1,-1), 0, 1);
+          vTex = aTex;
+        }
+      `);
+      gl.compileShader(vert);
+      const frag = gl.createShader(gl.FRAGMENT_SHADER);
+      gl.shaderSource(frag, `
+        precision mediump float;
+        uniform sampler2D uImg;
+        varying vec2 vTex;
+        void main() { gl_FragColor = texture2D(uImg, vTex); }
+      `);
+      gl.compileShader(frag);
+      const prog = gl.createProgram();
+      gl.attachShader(prog, vert);
+      gl.attachShader(prog, frag);
+      gl.linkProgram(prog);
+      gl.useProgram(prog);
+
+      const aPos = gl.getAttribLocation(prog, 'aPos');
+      const aTex = gl.getAttribLocation(prog, 'aTex');
+      const uResolution = gl.getUniformLocation(prog, 'uResolution');
+      gl.uniform2f(uResolution, this.surface.width, this.surface.height);
+
+      const verts = new Float32Array([
+        dx, dy, 0, 0,
+        dx + sw, dy, 1, 0,
+        dx, dy + sh, 0, 1,
+        dx + sw, dy + sh, 1, 1
+      ]);
+      const buf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STREAM_DRAW);
+      gl.enableVertexAttribArray(aPos);
+      gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 16, 0);
+      gl.enableVertexAttribArray(aTex);
+      gl.vertexAttribPointer(aTex, 2, gl.FLOAT, false, 16, 8);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+      gl.deleteTexture(tex);
+      gl.deleteProgram(prog);
+      gl.deleteShader(vert);
+      gl.deleteShader(frag);
+    } else {
+      // software backend
+      for (let y = 0; y < sh; y++) {
+        for (let x = 0; x < sw; x++) {
+          const pixel = srcSurface.getPixel(sx + x, sy + y);
+          this.surface.setPixel(dx + x, dy + y, pixel);
+        }
+      }
+    }
+  }
+
+  // Software implementations
+  _lineSoftware(x0, y0, x1, y1, rgba) {
+    let dx = Math.abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+    let dy = -Math.abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy, e2;
+    while (true) {
+      this.surface.setPixel(x0, y0, rgba);
+      if (x0 === x1 && y0 === y1) break;
+      e2 = 2 * err;
+      if (e2 >= dy) { err += dy; x0 += sx; }
+      if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+  }
+
+  _rectSoftware(x, y, w, h, rgba, fill) {
+    if (fill) {
+      for (let yy = 0; yy < h; yy++) {
+        for (let xx = 0; xx < w; xx++) {
+          this.surface.setPixel(x + xx, y + yy, rgba);
+        }
+      }
+    } else {
+      for (let xx = 0; xx < w; xx++) {
+        this.surface.setPixel(x + xx, y, rgba);
+        this.surface.setPixel(x + xx, y + h - 1, rgba);
+      }
+      for (let yy = 0; yy < h; yy++) {
+        this.surface.setPixel(x, y + yy, rgba);
+        this.surface.setPixel(x + w - 1, y + yy, rgba);
+      }
+    }
+  }
+}

--- a/kernel/executive/graphics/gdi.js
+++ b/kernel/executive/graphics/gdi.js
@@ -1,0 +1,12 @@
+import { Surface } from './surface.js';
+import { DeviceContext } from './deviceContext.js';
+
+export function createSurface(width, height, backend = 'canvas') {
+  return new Surface(width, height, backend);
+}
+
+export function createDeviceContext(surface) {
+  return new DeviceContext(surface);
+}
+
+export { Surface, DeviceContext };

--- a/kernel/executive/graphics/surface.js
+++ b/kernel/executive/graphics/surface.js
@@ -1,0 +1,80 @@
+export class Surface {
+  constructor(width, height, backend = 'canvas') {
+    this.width = width;
+    this.height = height;
+    this.backend = backend;
+
+    // Try canvas or webgl backends if environment supports them
+    if (backend === 'webgl' && typeof OffscreenCanvas !== 'undefined') {
+      this.canvas = new OffscreenCanvas(width, height);
+      this.gl =
+        this.canvas.getContext('webgl') ||
+        this.canvas.getContext('webgl2');
+      if (!this.gl) {
+        // Fallback to 2d canvas if WebGL not available
+        this.ctx = this.canvas.getContext('2d');
+        this.backend = 'canvas';
+      }
+    } else if (backend === 'canvas' && typeof OffscreenCanvas !== 'undefined') {
+      this.canvas = new OffscreenCanvas(width, height);
+      this.ctx = this.canvas.getContext('2d');
+    }
+
+    if (!this.canvas) {
+      // Software fallback using raw pixel buffer
+      this.backend = 'software';
+      this.buffer = new Uint8ClampedArray(width * height * 4);
+    }
+  }
+
+  // Utility for software buffer
+  _index(x, y) {
+    return (y * this.width + x) * 4;
+  }
+
+  setPixel(x, y, rgba) {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return;
+    if (this.backend === 'software') {
+      const idx = this._index(x, y);
+      const [r, g, b, a] = rgba;
+      this.buffer[idx] = r;
+      this.buffer[idx + 1] = g;
+      this.buffer[idx + 2] = b;
+      this.buffer[idx + 3] = a;
+    } else if (this.ctx) {
+      const [r, g, b, a] = rgba;
+      const image = new Uint8ClampedArray([r, g, b, a]);
+      const data = new ImageData(image, 1, 1);
+      this.ctx.putImageData(data, x, y);
+    } else if (this.gl) {
+      // WebGL single pixel draw using scissor + clear
+      const [r, g, b, a] = rgba.map(v => v / 255);
+      this.gl.enable(this.gl.SCISSOR_TEST);
+      this.gl.scissor(x, this.height - y - 1, 1, 1);
+      this.gl.clearColor(r, g, b, a);
+      this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+      this.gl.disable(this.gl.SCISSOR_TEST);
+    }
+  }
+
+  getPixel(x, y) {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return [0, 0, 0, 0];
+    if (this.backend === 'software') {
+      const idx = this._index(x, y);
+      return [
+        this.buffer[idx],
+        this.buffer[idx + 1],
+        this.buffer[idx + 2],
+        this.buffer[idx + 3]
+      ];
+    } else if (this.ctx) {
+      const data = this.ctx.getImageData(x, y, 1, 1).data;
+      return [data[0], data[1], data[2], data[3]];
+    } else if (this.gl) {
+      const pixel = new Uint8Array(4);
+      this.gl.readPixels(x, this.height - y - 1, 1, 1, this.gl.RGBA, this.gl.UNSIGNED_BYTE, pixel);
+      return [pixel[0], pixel[1], pixel[2], pixel[3]];
+    }
+    return [0, 0, 0, 0];
+  }
+}

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createSurface, createDeviceContext } from '../kernel/executive/graphics/gdi.js';
+
+function rgbaEqual(a, b) {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+}
+
+test('line draws on surface', () => {
+  const s = createSurface(10, 10, 'software');
+  const dc = createDeviceContext(s);
+  dc.line(0, 0, 9, 9, '#ff0000');
+  const p = s.getPixel(5, 5);
+  assert(rgbaEqual(p, [255, 0, 0, 255]));
+});
+
+test('rectangle draws border', () => {
+  const s = createSurface(10, 10, 'software');
+  const dc = createDeviceContext(s);
+  dc.rect(1, 1, 8, 8, '#00ff00');
+  assert(rgbaEqual(s.getPixel(1, 1), [0, 255, 0, 255]));
+  assert(rgbaEqual(s.getPixel(8, 1), [0, 255, 0, 255]));
+  assert(rgbaEqual(s.getPixel(1, 8), [0, 255, 0, 255]));
+});
+
+test('blit copies pixels between surfaces', () => {
+  const src = createSurface(5, 5, 'software');
+  const dcs = createDeviceContext(src);
+  dcs.rect(0, 0, 5, 5, '#0000ff', true);
+  const dst = createSurface(5, 5, 'software');
+  const dcd = createDeviceContext(dst);
+  dcd.blit(src, 0, 0, 5, 5, 0, 0);
+  assert(rgbaEqual(dst.getPixel(2, 2), [0, 0, 255, 255]));
+});


### PR DESCRIPTION
## Summary
- add graphics surface abstraction with canvas/webgl/software backends
- implement device context with line, rect, and blit primitives
- expose GDI-style helpers and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6892e279988883298f6e19936d89881c