### PR TITLE
Add basic system services modules

### DIFF
--- a/system/registry.js
+++ b/system/registry.js
@@ -1,0 +1,33 @@
+export class Registry {
+  constructor() {
+    this.store = new Map();
+  }
+
+  create(key, value) {
+    if (this.store.has(key)) {
+      throw new Error('Key already exists');
+    }
+    this.store.set(key, value);
+  }
+
+  read(key) {
+    return this.store.get(key);
+  }
+
+  update(key, value) {
+    if (!this.store.has(key)) {
+      throw new Error('Key not found');
+    }
+    this.store.set(key, value);
+  }
+
+  delete(key) {
+    this.store.delete(key);
+  }
+
+  keys() {
+    return Array.from(this.store.keys());
+  }
+}
+
+export const registry = new Registry();

--- a/system/serviceManager.js
+++ b/system/serviceManager.js
@@ -1,0 +1,40 @@
+export class ServiceManager {
+  constructor() {
+    this.services = new Map();
+  }
+
+  register(name, service) {
+    this.services.set(name, { service, running: false });
+  }
+
+  async start(name, ...args) {
+    const entry = this.services.get(name);
+    if (!entry) {
+      throw new Error(`Unknown service: ${name}`);
+    }
+    if (entry.running) return;
+    if (typeof entry.service.start === 'function') {
+      await entry.service.start(...args);
+    }
+    entry.running = true;
+  }
+
+  async stop(name, ...args) {
+    const entry = this.services.get(name);
+    if (!entry) {
+      throw new Error(`Unknown service: ${name}`);
+    }
+    if (!entry.running) return;
+    if (typeof entry.service.stop === 'function') {
+      await entry.service.stop(...args);
+    }
+    entry.running = false;
+  }
+
+  isRunning(name) {
+    const entry = this.services.get(name);
+    return entry ? entry.running : false;
+  }
+}
+
+export const serviceManager = new ServiceManager();

--- a/system/syscall.js
+++ b/system/syscall.js
@@ -1,0 +1,32 @@
+export class SyscallDispatcher {
+  constructor() {
+    this.serviceTable = new Map();
+    this.trapHandlers = new Map();
+  }
+
+  registerService(number, handler) {
+    this.serviceTable.set(number, handler);
+  }
+
+  registerTrap(trap, handler) {
+    this.trapHandlers.set(trap, handler);
+  }
+
+  invoke(number, ...args) {
+    const fn = this.serviceTable.get(number);
+    if (!fn) {
+      throw new Error(`Invalid system call: ${number}`);
+    }
+    return fn(...args);
+  }
+
+  trap(trap, ...args) {
+    const handler = this.trapHandlers.get(trap);
+    if (!handler) {
+      throw new Error(`Unhandled trap: ${trap}`);
+    }
+    return handler(...args);
+  }
+}
+
+export const syscall = new SyscallDispatcher();

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Registry } from '../system/registry.js';
+
+test('registry provides CRUD operations', () => {
+  const reg = new Registry();
+  reg.create('foo', 'bar');
+  assert.strictEqual(reg.read('foo'), 'bar');
+  reg.update('foo', 'baz');
+  assert.strictEqual(reg.read('foo'), 'baz');
+  reg.delete('foo');
+  assert.strictEqual(reg.read('foo'), undefined);
+});

--- a/test/serviceManager.test.js
+++ b/test/serviceManager.test.js
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { ServiceManager } from '../system/serviceManager.js';
+
+test('service manager starts and stops services', async () => {
+  const manager = new ServiceManager();
+  const events = [];
+  manager.register('demo', {
+    start: () => events.push('start'),
+    stop: () => events.push('stop')
+  });
+  await manager.start('demo');
+  assert.strictEqual(manager.isRunning('demo'), true);
+  await manager.stop('demo');
+  assert.deepStrictEqual(events, ['start', 'stop']);
+  assert.strictEqual(manager.isRunning('demo'), false);
+});

--- a/test/syscall.test.js
+++ b/test/syscall.test.js
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { SyscallDispatcher } from '../system/syscall.js';
+
+test('syscall dispatcher routes to service table', () => {
+  const sys = new SyscallDispatcher();
+  sys.registerService(1, (a, b) => a + b);
+  assert.strictEqual(sys.invoke(1, 2, 3), 5);
+});
+
+test('syscall dispatcher handles traps', () => {
+  const sys = new SyscallDispatcher();
+  sys.registerTrap('pageFault', addr => `handled ${addr}`);
+  assert.strictEqual(sys.trap('pageFault', '0x1'), 'handled 0x1');
+});


### PR DESCRIPTION
## Summary
- add SyscallDispatcher for service table and trap handlers
- introduce ServiceManager to start and stop services
- provide Registry with CRUD operations
- cover new system modules with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6892e653c5e08329b5d0e6b756d6f8cb