### PR TITLE
feat(win32): add user mode kernel stubs

### DIFF
--- a/test/win32api.test.js
+++ b/test/win32api.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import * as kernel32 from '../usermode/win32/kernel32.js';
+import * as user32 from '../usermode/win32/user32.js';
+import * as gdi32 from '../usermode/win32/gdi32.js';
+import { syscall } from '../system/syscall.js';
+
+test('kernel32 WriteConsole maps to syscall', () => {
+  let invoked = false;
+  syscall.registerService(kernel32.KERNEL32_SERVICES.WRITE_CONSOLE, (handle, msg) => {
+    invoked = true;
+    return msg.length;
+  });
+  const len = kernel32.WriteConsole(1, 'hi');
+  assert.strictEqual(len, 2);
+  assert.ok(invoked);
+});
+
+test('kernel32 AllocConsole returns handle', () => {
+  syscall.registerService(kernel32.KERNEL32_SERVICES.ALLOC_CONSOLE, () => true);
+  assert.strictEqual(kernel32.AllocConsole(), 1);
+});
+
+test('user32 MessageBox maps to syscall', () => {
+  syscall.registerService(user32.USER32_SERVICES.MESSAGE_BOX, (hwnd, text, caption, type) => `${caption}: ${text}`);
+  assert.strictEqual(user32.MessageBox(null, 'hello', 'title'), 'title: hello');
+});
+
+test('user32 message queue stores and retrieves', () => {
+  user32.PostMessage({ type: 'ping' });
+  assert.deepStrictEqual(user32.GetMessage(), { type: 'ping' });
+});
+
+test('gdi32 TextOut maps to syscall', () => {
+  syscall.registerService(gdi32.GDI32_SERVICES.TEXT_OUT, (dc, x, y, text) => `${text}@${x},${y}`);
+  assert.strictEqual(gdi32.TextOut(1, 10, 20, 'draw'), 'draw@10,20');
+});

--- a/usermode/win32/gdi32.js
+++ b/usermode/win32/gdi32.js
@@ -1,0 +1,19 @@
+import { syscall } from '../../system/syscall.js';
+
+export const GDI32_SERVICES = {
+  CREATE_DC: 0x3000,
+  DELETE_DC: 0x3001,
+  TEXT_OUT: 0x3002
+};
+
+export function CreateCompatibleDC(hdc = 0) {
+  return syscall.invoke(GDI32_SERVICES.CREATE_DC, hdc);
+}
+
+export function DeleteDC(hdc) {
+  return syscall.invoke(GDI32_SERVICES.DELETE_DC, hdc);
+}
+
+export function TextOut(hdc, x, y, text) {
+  return syscall.invoke(GDI32_SERVICES.TEXT_OUT, hdc, x, y, text);
+}

--- a/usermode/win32/kernel32.js
+++ b/usermode/win32/kernel32.js
@@ -1,0 +1,38 @@
+import { syscall } from '../../system/syscall.js';
+
+export const KERNEL32_SERVICES = {
+  CREATE_PROCESS: 0x1000,
+  EXIT_PROCESS: 0x1001,
+  SLEEP: 0x1002,
+  ALLOC_CONSOLE: 0x1003,
+  WRITE_CONSOLE: 0x1004
+};
+
+// Basic console handle for userland apps. In a real system this would
+// be an object managed by the kernel. Here we simply expose a fixed
+// handle and echo to Node's console for demonstration purposes.
+const CONSOLE_HANDLE = 1;
+
+export function CreateProcess(executable, args = []) {
+  return syscall.invoke(KERNEL32_SERVICES.CREATE_PROCESS, executable, args);
+}
+
+export function ExitProcess(code = 0) {
+  return syscall.invoke(KERNEL32_SERVICES.EXIT_PROCESS, code);
+}
+
+export function Sleep(ms) {
+  return syscall.invoke(KERNEL32_SERVICES.SLEEP, ms);
+}
+
+export function AllocConsole() {
+  syscall.invoke(KERNEL32_SERVICES.ALLOC_CONSOLE);
+  return CONSOLE_HANDLE;
+}
+
+export function WriteConsole(handle, message) {
+  if (handle === CONSOLE_HANDLE) {
+    console.log(message);
+  }
+  return syscall.invoke(KERNEL32_SERVICES.WRITE_CONSOLE, handle, message);
+}

--- a/usermode/win32/user32.js
+++ b/usermode/win32/user32.js
@@ -1,0 +1,40 @@
+import { syscall } from '../../system/syscall.js';
+
+export const USER32_SERVICES = {
+  CREATE_WINDOW: 0x2000,
+  SHOW_WINDOW: 0x2001,
+  MESSAGE_BOX: 0x2002,
+  DISPATCH_MESSAGE: 0x2003
+};
+
+// A tiny message queue to emulate the cooperative message loop used by
+// Win32 applications. Applications can post messages which are later
+// retrieved with GetMessage.
+const messageQueue = [];
+
+export function CreateWindow(className, windowName, x, y, width, height, opts = {}) {
+  return syscall.invoke(
+    USER32_SERVICES.CREATE_WINDOW,
+    { className, windowName, x, y, width, height, opts }
+  );
+}
+
+export function ShowWindow(hwnd, cmd) {
+  return syscall.invoke(USER32_SERVICES.SHOW_WINDOW, hwnd, cmd);
+}
+
+export function MessageBox(hwnd, text, caption, type = 0) {
+  return syscall.invoke(USER32_SERVICES.MESSAGE_BOX, hwnd, text, caption, type);
+}
+
+export function DispatchMessage(msg) {
+  return syscall.invoke(USER32_SERVICES.DISPATCH_MESSAGE, msg);
+}
+
+export function PostMessage(msg) {
+  messageQueue.push(msg);
+}
+
+export function GetMessage() {
+  return messageQueue.shift() ?? null;
+}


### PR DESCRIPTION
## Summary
- add `kernel32`, `user32`, and `gdi32` user-mode modules
- map exported functions to syscall services and stub console/window hooks
- cover new APIs with basic tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6892e83222c483298198d5b5a922c336