### PR TITLE
Add scheduler and integration tests

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import bootstrap from '../kernel/bootstrap.js';
+import { NetworkInterface, registerInterface, _clear } from '../kernel/executive/net/ip.js';
+import { createSocket as createUDPSocket } from '../kernel/executive/net/udp.js';
+import { Thread } from '../kernel/thread.js';
+
+// Integration test: processes performing I/O and network operations through scheduler
+
+test('processes perform I/O and network operations', async () => {
+  const { scheduler, deviceManager } = await bootstrap();
+  _clear();
+  const ifaceA = new NetworkInterface('10.0.0.1');
+  const ifaceB = new NetworkInterface('10.0.0.2');
+  registerInterface(ifaceA);
+  registerInterface(ifaceB);
+
+  let received = '';
+  const recvProc = scheduler.createProcess(1);
+  const recvThread = new Thread(async () => {
+    const sock = createUDPSocket(ifaceB, 5000);
+    await new Promise(resolve => {
+      sock.on('message', (data) => { received = data.toString(); resolve(); });
+    });
+  });
+  recvProc.addThread(recvThread);
+
+  const sendProc = scheduler.createProcess(1);
+  const sendThread = new Thread(async () => {
+    const result = deviceManager.sendRequest('storage', 'read');
+    assert.strictEqual(result, 'storage:read');
+    const sock = createUDPSocket(ifaceA, 4000);
+    sock.send('10.0.0.2', 5000, Buffer.from('hello'));
+  });
+  sendProc.addThread(sendThread);
+
+  scheduler.contextSwitch(recvProc);
+  const recvPromise = recvThread.start();
+  scheduler.contextSwitch(sendProc);
+  await sendThread.start();
+  await recvPromise;
+  assert.strictEqual(received, 'hello');
+});

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Scheduler, Mutex, Semaphore, Spinlock } from '../kernel/scheduler.js';
+
+// Test that scheduler prioritizes higher priority processes
+
+test('scheduler selects highest priority process first', () => {
+  const sched = new Scheduler();
+  sched.createProcess(1);
+  sched.createProcess(5);
+  sched.schedule();
+  assert.strictEqual(sched.current.priority, 5);
+  // Simulate current process blocking so next process can run
+  sched.current.state = 'waiting';
+  sched.schedule();
+  assert.strictEqual(sched.current.priority, 1);
+});
+
+// Test Mutex
+
+test('mutex enforces mutual exclusion', async () => {
+  const m = new Mutex();
+  const order = [];
+  await m.lock();
+  order.push('a');
+  const later = m.lock().then(() => {
+    order.push('b');
+    m.unlock();
+  });
+  m.unlock();
+  await later;
+  assert.deepStrictEqual(order, ['a', 'b']);
+});
+
+// Test Semaphore
+
+test('semaphore manages concurrent access', async () => {
+  const s = new Semaphore(1);
+  const order = [];
+  await s.wait();
+  order.push('a');
+  const waiter = s.wait().then(() => {
+    order.push('b');
+  });
+  order.push('c');
+  s.signal();
+  await waiter;
+  assert.deepStrictEqual(order, ['a', 'c', 'b']);
+});
+
+// Test Spinlock
+
+test('spinlock provides exclusive access', async () => {
+  const lock = new Spinlock();
+  let counter = 0;
+  const inc = async () => {
+    await lock.lock();
+    const current = counter;
+    await new Promise(r => setTimeout(r, 5));
+    counter = current + 1;
+    lock.unlock();
+  };
+  await Promise.all([inc(), inc()]);
+  assert.strictEqual(counter, 2);
+});


### PR DESCRIPTION
## Summary
- add scheduler unit tests covering priority scheduling and sync primitives
- add integration test exercising process scheduling, storage I/O, and UDP networking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6892ec0a00e8832987428474c8582f3e