### PR TITLE
Add preemptive scheduler with configurable time slice

### DIFF
--- a/kernel/bootstrap.js
+++ b/kernel/bootstrap.js
@@ -63,6 +63,7 @@ export async function bootstrap(options = {}) {
   const idleThread = new Thread(() => {});
   idleProcess.addThread(idleThread);
   scheduler.contextSwitch(idleProcess);
+  scheduler.start();
 
   // Launch initial system services
   for (const { name, service } of services) {

--- a/kernel/thread.js
+++ b/kernel/thread.js
@@ -5,7 +5,15 @@ export class Thread {
     this.tid = nextTid++;
     this.entry = entry;
     this.state = 'ready';
-    this.context = {};
+    this.context = { registers: {}, sp: 0 };
+  }
+
+  saveContext(ctx) {
+    this.context = { ...ctx };
+  }
+
+  loadContext() {
+    return { ...this.context };
   }
 
   async start(...args) {


### PR DESCRIPTION
## Summary
- introduce time-sliced preemptive Scheduler using HAL timer
- save/restore thread CPU context on context switches
- expose APIs to adjust process priority and scheduler time slice
- start scheduler during bootstrap and expand tests

## Testing
- `npm test`
- `node --test test/scheduler.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6892fa263bc48329b8cbad9f4d1ee921