### PR TITLE
Add Win32 service handlers and unit tests

### DIFF
--- a/kernel/bootstrap.js
+++ b/kernel/bootstrap.js
@@ -8,6 +8,10 @@ import InputDriver from './io/drivers/input.js';
 import NetworkDriver from './io/drivers/network.js';
 import StorageDriver from './io/drivers/storage.js';
 import { serviceManager } from '../system/serviceManager.js';
+import { syscall } from '../system/syscall.js';
+import { registerKernel32 } from '../system/services/kernel32.js';
+import { registerUser32 } from '../system/services/user32.js';
+import { registerGdi32 } from '../system/services/gdi32.js';
 
 /**
  * Bootstraps the kernel and core subsystems.
@@ -64,6 +68,11 @@ export async function bootstrap(options = {}) {
   idleProcess.addThread(idleThread);
   scheduler.contextSwitch(idleProcess);
   scheduler.start();
+
+  // Register core system call services
+  registerKernel32(syscall, scheduler);
+  registerUser32(syscall);
+  registerGdi32(syscall);
 
   // Launch initial system services
   for (const { name, service } of services) {

--- a/system/services/gdi32.js
+++ b/system/services/gdi32.js
@@ -1,0 +1,22 @@
+import { GDI32_SERVICES } from '../../usermode/win32/gdi32.js';
+
+export const textOutputs = [];
+
+export function createDC(hdc = 0) {
+  return 1;
+}
+
+export function deleteDC(hdc) {
+  return true;
+}
+
+export function textOut(hdc, x, y, text) {
+  textOutputs.push({ hdc, x, y, text });
+  return text.length;
+}
+
+export function registerGdi32(syscall) {
+  syscall.registerService(GDI32_SERVICES.CREATE_DC, createDC);
+  syscall.registerService(GDI32_SERVICES.DELETE_DC, deleteDC);
+  syscall.registerService(GDI32_SERVICES.TEXT_OUT, textOut);
+}

--- a/system/services/kernel32.js
+++ b/system/services/kernel32.js
@@ -1,0 +1,35 @@
+import { KERNEL32_SERVICES } from '../../usermode/win32/kernel32.js';
+
+let schedulerRef;
+
+export function createProcess(executable, args = []) {
+  const proc = schedulerRef.createProcess();
+  proc.image = executable;
+  proc.args = args;
+  return proc.pid;
+}
+
+export function exitProcess(code = 0) {
+  return code;
+}
+
+export function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function allocConsole() {
+  return true;
+}
+
+export function writeConsole(handle, message) {
+  return message.length;
+}
+
+export function registerKernel32(syscall, scheduler) {
+  schedulerRef = scheduler;
+  syscall.registerService(KERNEL32_SERVICES.CREATE_PROCESS, createProcess);
+  syscall.registerService(KERNEL32_SERVICES.EXIT_PROCESS, exitProcess);
+  syscall.registerService(KERNEL32_SERVICES.SLEEP, sleep);
+  syscall.registerService(KERNEL32_SERVICES.ALLOC_CONSOLE, allocConsole);
+  syscall.registerService(KERNEL32_SERVICES.WRITE_CONSOLE, writeConsole);
+}

--- a/system/services/user32.js
+++ b/system/services/user32.js
@@ -1,0 +1,34 @@
+import { USER32_SERVICES } from '../../usermode/win32/user32.js';
+
+export const windows = new Map();
+let nextHwnd = 1;
+
+export function createWindow(params) {
+  const hwnd = nextHwnd++;
+  windows.set(hwnd, { ...params, visible: false });
+  return hwnd;
+}
+
+export function showWindow(hwnd, cmd) {
+  const win = windows.get(hwnd);
+  if (win) {
+    win.visible = cmd !== 0;
+    return true;
+  }
+  return false;
+}
+
+export function messageBox(hwnd, text, caption, type = 0) {
+  return `${caption}: ${text}`;
+}
+
+export function dispatchMessage(msg) {
+  return msg;
+}
+
+export function registerUser32(syscall) {
+  syscall.registerService(USER32_SERVICES.CREATE_WINDOW, createWindow);
+  syscall.registerService(USER32_SERVICES.SHOW_WINDOW, showWindow);
+  syscall.registerService(USER32_SERVICES.MESSAGE_BOX, messageBox);
+  syscall.registerService(USER32_SERVICES.DISPATCH_MESSAGE, dispatchMessage);
+}

--- a/test/serviceHandlers.test.js
+++ b/test/serviceHandlers.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import bootstrap from '../kernel/bootstrap.js';
+import * as k32 from '../usermode/win32/kernel32.js';
+import * as u32 from '../usermode/win32/user32.js';
+import * as g32 from '../usermode/win32/gdi32.js';
+import { windows } from '../system/services/user32.js';
+import { textOutputs } from '../system/services/gdi32.js';
+
+ test('CreateProcess via kernel32 triggers scheduler', async () => {
+  const { scheduler } = await bootstrap();
+  const pid = k32.CreateProcess('app.exe');
+  const proc = scheduler.table.getProcess(pid);
+  assert.ok(proc);
+  assert.strictEqual(proc.image, 'app.exe');
+  scheduler.stop();
+});
+
+test('CreateWindow via user32 stores window', async () => {
+  windows.clear();
+  const { scheduler } = await bootstrap();
+  const hwnd = u32.CreateWindow('cls', 'win', 0, 0, 100, 100);
+  assert.ok(windows.has(hwnd));
+  scheduler.stop();
+});
+
+test('GDI TextOut records output', async () => {
+  textOutputs.length = 0;
+  const { scheduler } = await bootstrap();
+  g32.TextOut(1, 5, 6, 'hello');
+  assert.deepStrictEqual(textOutputs.pop(), { hdc: 1, x: 5, y: 6, text: 'hello' });
+  scheduler.stop();
+});


### PR DESCRIPTION
## Summary
- add kernel32, user32 and gdi32 service handler modules
- register handlers in kernel bootstrap via syscall dispatcher
- test that user-mode calls trigger kernel behavior

## Testing
- `node --experimental-json-modules --test test/serviceHandlers.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689308895fb08329907afff28e1c6888