### PR TITLE
Add user authentication and token enforcement

### DIFF
--- a/kernel/executive/security/users.js
+++ b/kernel/executive/security/users.js
@@ -1,0 +1,28 @@
+import crypto from 'node:crypto';
+import { createToken } from '../security.js';
+
+const users = new Map();
+const loggedOn = new Set();
+
+function hash(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export function addUser(username, password, groups = []) {
+  const sid = `S-${users.size + 1}`;
+  users.set(username, { sid, groups, passwordHash: hash(password) });
+  return sid;
+}
+
+export function logonUser(username, password) {
+  const user = users.get(username);
+  if (!user) return null;
+  if (user.passwordHash !== hash(password)) return null;
+  const token = createToken(user.sid, user.groups);
+  loggedOn.add(token);
+  return token;
+}
+
+export function isLoggedOn(token) {
+  return loggedOn.has(token);
+}

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { addUser, logonUser } from '../kernel/executive/security/users.js';
+import { checkAccess } from '../kernel/executive/security.js';
+import { ProcessTable } from '../kernel/process.js';
+
+test('logonUser authenticates credentials', () => {
+  addUser('bob', 'secret');
+  assert.ok(logonUser('bob', 'secret'));
+  assert.strictEqual(logonUser('bob', 'wrong'), null);
+});
+
+test('impersonation affects privileges', () => {
+  addUser('admin', 'pass');
+  const admin = logonUser('admin', 'pass');
+  admin.privileges.add('createProcess');
+
+  addUser('guest', 'guest');
+  const guest = logonUser('guest', 'guest');
+
+  const table = new ProcessTable();
+  table.createProcess(0, admin);
+
+  admin.impersonate(guest);
+  assert.throws(() => table.createProcess(0, admin));
+  admin.revertToSelf();
+  const proc = table.createProcess(0, admin);
+  assert.strictEqual(proc.pid, 2);
+});
+
+test('ACL enforces group access', () => {
+  const group = 'editors';
+  addUser('carol', 'pw', [group]);
+  const carol = logonUser('carol', 'pw');
+  const entry = {
+    rights: new Set(['read']),
+    acl: new Map([[group, new Set(['write'])]])
+  };
+  assert.ok(checkAccess(carol, entry, ['write']));
+
+  addUser('dave', 'pw');
+  const dave = logonUser('dave', 'pw');
+  assert.ok(!checkAccess(dave, entry, ['write']));
+  assert.ok(checkAccess(dave, entry, ['read']));
+});


### PR DESCRIPTION
## Summary
- manage user records with hashed passwords and login tokens
- require logged-on or system token for process creation
- test logon, impersonation, and ACL access control

## Testing
- `npm test`
- `node --experimental-json-modules --test test/processSecurity.test.js`
- `node --experimental-json-modules --test test/security.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6893130e19e0832999f6a34939659d8c