### PR TITLE
Add PnP management and power handling

### DIFF
--- a/kernel/io/deviceManager.js
+++ b/kernel/io/deviceManager.js
@@ -1,8 +1,19 @@
-import { interruptController } from '../../src/lib/hal/index.js';
+import { interruptController, powerManagement } from '../../src/lib/hal/index.js';
+import pnpManager from '../pnp/index.js';
 
 export class DeviceManager {
   constructor() {
     this.drivers = new Map();
+    this.factories = new Map();
+    pnpManager.onHotPlug(event => {
+      if (event.type === 'add') {
+        this.loadDriverForDevice(event.device);
+        powerManagement.setDeviceState(event.device.id, 'on');
+      } else if (event.type === 'remove') {
+        this.unloadDriver(event.device.id);
+        powerManagement.setDeviceState(event.device.id, 'off');
+      }
+    });
   }
 
   registerDriver(driver) {
@@ -14,6 +25,31 @@ export class DeviceManager {
         }
       });
     }
+  }
+
+  unregisterDriver(name) {
+    const driver = this.drivers.get(name);
+    if (!driver) return;
+    if (driver.irq) {
+      interruptController.clear(driver.irq);
+    }
+    this.drivers.delete(name);
+  }
+
+  registerDriverFactory(type, factory) {
+    this.factories.set(type, factory);
+  }
+
+  loadDriverForDevice(device) {
+    const Factory = this.factories.get(device.type);
+    if (!Factory) return;
+    const driver = new Factory();
+    driver.name = device.id;
+    this.registerDriver(driver);
+  }
+
+  unloadDriver(deviceId) {
+    this.unregisterDriver(deviceId);
   }
 
   sendRequest(name, request) {
@@ -31,6 +67,7 @@ export class DeviceManager {
       }
     }
     this.drivers.clear();
+    this.factories.clear();
   }
 }
 

--- a/kernel/pnp/index.js
+++ b/kernel/pnp/index.js
@@ -1,0 +1,44 @@
+export class PnPManager {
+  constructor() {
+    this.devices = new Map();
+    this.listeners = new Set();
+    this.resourceCounter = 0;
+  }
+
+  enumerate() {
+    return Array.from(this.devices.values());
+  }
+
+  onHotPlug(listener) {
+    this.listeners.add(listener);
+  }
+
+  offHotPlug(listener) {
+    this.listeners.delete(listener);
+  }
+
+  addDevice(device) {
+    const dev = { ...device, resourceId: ++this.resourceCounter };
+    this.devices.set(dev.id, dev);
+    for (const l of this.listeners) {
+      l({ type: 'add', device: dev });
+    }
+  }
+
+  removeDevice(id) {
+    const dev = this.devices.get(id);
+    if (!dev) return;
+    this.devices.delete(id);
+    for (const l of this.listeners) {
+      l({ type: 'remove', device: dev });
+    }
+  }
+
+  reset() {
+    this.devices.clear();
+    this.resourceCounter = 0;
+  }
+}
+
+export const pnpManager = new PnPManager();
+export default pnpManager;

--- a/src/lib/hal/index.js
+++ b/src/lib/hal/index.js
@@ -37,16 +37,33 @@ export const timer = {
 };
 
 export const powerManagement = (() => {
-  let state = 'on';
+  let systemState = 'on';
+  const deviceStates = new Map();
   return {
     shutdown() {
-      state = 'off';
+      systemState = 'off';
     },
     reboot() {
-      state = 'rebooting';
+      systemState = 'rebooting';
+    },
+    sleep() {
+      systemState = 'sleep';
+    },
+    hibernate() {
+      systemState = 'hibernate';
     },
     getState() {
-      return state;
+      return systemState;
+    },
+    setDeviceState(id, state) {
+      deviceStates.set(id, state);
+    },
+    getDeviceState(id) {
+      return deviceStates.get(id) ?? 'on';
+    },
+    reset() {
+      systemState = 'on';
+      deviceStates.clear();
     }
   };
 })();

--- a/test/hal.test.js
+++ b/test/hal.test.js
@@ -29,3 +29,16 @@ test('powerManagement tracks power state', () => {
   powerManagement.reboot();
   assert.strictEqual(powerManagement.getState(), 'rebooting');
 });
+
+test('powerManagement handles sleep and hibernate', () => {
+  powerManagement.sleep();
+  assert.strictEqual(powerManagement.getState(), 'sleep');
+  powerManagement.hibernate();
+  assert.strictEqual(powerManagement.getState(), 'hibernate');
+});
+
+test('powerManagement tracks per-device states', () => {
+  powerManagement.setDeviceState('dev1', 'off');
+  assert.strictEqual(powerManagement.getDeviceState('dev1'), 'off');
+  powerManagement.reset();
+});

--- a/test/pnp.test.js
+++ b/test/pnp.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import deviceManager from '../kernel/io/deviceManager.js';
+import pnpManager from '../kernel/pnp/index.js';
+import NetworkDriver from '../kernel/io/drivers/network.js';
+import StorageDriver from '../kernel/io/drivers/storage.js';
+
+function setup() {
+  deviceManager.reset();
+  pnpManager.reset();
+}
+
+test('deviceManager loads and unloads drivers on device events', () => {
+  setup();
+  deviceManager.registerDriverFactory('network', NetworkDriver);
+  pnpManager.addDevice({ id: 'net0', type: 'network' });
+  assert.strictEqual(deviceManager.sendRequest('net0', 'send'), 'network:send');
+  pnpManager.removeDevice('net0');
+  assert.throws(() => deviceManager.sendRequest('net0', 'send'));
+});
+
+test('pnp manager enumerates devices and allocates resources', () => {
+  setup();
+  deviceManager.registerDriverFactory('storage', StorageDriver);
+  pnpManager.addDevice({ id: 'disk1', type: 'storage' });
+  const devices = pnpManager.enumerate();
+  assert.strictEqual(devices.length, 1);
+  assert.strictEqual(devices[0].id, 'disk1');
+  assert.ok(devices[0].resourceId);
+});


### PR DESCRIPTION
## Summary
- introduce kernel-level PnP manager for device discovery, hot-plug events and resource tracking
- extend HAL power management with sleep, hibernate and per-device states
- auto-load and unload drivers through device manager on PnP events

## Testing
- `node --experimental-json-modules --test test/hal.test.js test/pnp.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68932df3c85c832986baf4eb33f68461