### PR TITLE
feat: add basic ipc subsystem

### DIFF
--- a/kernel/ipc/index.js
+++ b/kernel/ipc/index.js
@@ -1,0 +1,4 @@
+export * from './lpc.js';
+export * from './namedPipe.js';
+export * from './mailslot.js';
+export * from './sharedMemory.js';

--- a/kernel/ipc/lpc.js
+++ b/kernel/ipc/lpc.js
@@ -1,0 +1,33 @@
+import { EventEmitter } from 'events';
+import { objectManager } from '../executive/objectManager.js';
+import { systemToken } from '../executive/security.js';
+
+export class LpcPort extends EventEmitter {
+  constructor() {
+    super();
+  }
+
+  send(message) {
+    this.emit('message', message);
+  }
+}
+
+export function createLpcPort(path, options = {}, token = systemToken) {
+  const port = new LpcPort();
+  objectManager.registerObject(path, port, options);
+  return objectManager.openHandle(path, ['read', 'write'], token);
+}
+
+export function connectLpcPort(path, token = systemToken) {
+  return objectManager.openHandle(path, ['read', 'write'], token);
+}
+
+export function lpcSend(handle, message) {
+  const port = objectManager.getObject(handle, ['write']);
+  port.send(message);
+}
+
+export function lpcOnMessage(handle, handler) {
+  const port = objectManager.getObject(handle, ['read']);
+  port.on('message', handler);
+}

--- a/kernel/ipc/mailslot.js
+++ b/kernel/ipc/mailslot.js
@@ -1,0 +1,34 @@
+import { objectManager } from '../executive/objectManager.js';
+import { systemToken } from '../executive/security.js';
+
+class MailSlot {
+  constructor() {
+    this.messages = [];
+  }
+  write(msg) {
+    this.messages.push(msg);
+  }
+  read() {
+    return this.messages.shift();
+  }
+}
+
+export function createMailslot(path, options = {}, token = systemToken) {
+  const slot = new MailSlot();
+  objectManager.registerObject(path, slot, options);
+  return objectManager.openHandle(path, ['read', 'write'], token);
+}
+
+export function openMailslot(path, rights = ['read', 'write'], token = systemToken) {
+  return objectManager.openHandle(path, rights, token);
+}
+
+export function writeMailslot(handle, msg) {
+  const slot = objectManager.getObject(handle, ['write']);
+  slot.write(msg);
+}
+
+export function readMailslot(handle) {
+  const slot = objectManager.getObject(handle, ['read']);
+  return slot.read();
+}

--- a/kernel/ipc/namedPipe.js
+++ b/kernel/ipc/namedPipe.js
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'events';
+import { objectManager } from '../executive/objectManager.js';
+import { systemToken } from '../executive/security.js';
+
+class PipeCore extends EventEmitter {
+  constructor() {
+    super();
+    this.buffer = [];
+  }
+
+  write(data) {
+    this.buffer.push(data);
+    this.emit('data');
+  }
+
+  read() {
+    return this.buffer.shift();
+  }
+}
+
+export function createNamedPipe(path, options = {}, token = systemToken) {
+  const pipe = new PipeCore();
+  objectManager.registerObject(path, pipe, options);
+  const readHandle = objectManager.openHandle(path, ['read'], token);
+  const writeHandle = objectManager.openHandle(path, ['write'], token);
+  return { readHandle, writeHandle };
+}
+
+export function openNamedPipe(path, rights = ['read', 'write'], token = systemToken) {
+  return objectManager.openHandle(path, rights, token);
+}
+
+export function writePipe(handle, data) {
+  const pipe = objectManager.getObject(handle, ['write']);
+  pipe.write(data);
+}
+
+export function readPipe(handle) {
+  const pipe = objectManager.getObject(handle, ['read']);
+  return pipe.read();
+}

--- a/kernel/ipc/sharedMemory.js
+++ b/kernel/ipc/sharedMemory.js
@@ -1,0 +1,34 @@
+import { objectManager } from '../executive/objectManager.js';
+import { systemToken } from '../executive/security.js';
+
+class SharedMemory {
+  constructor(size) {
+    this.buffer = Buffer.alloc(size);
+  }
+  write(offset, data) {
+    Buffer.from(data).copy(this.buffer, offset);
+  }
+  read(offset, length) {
+    return this.buffer.slice(offset, offset + length);
+  }
+}
+
+export function createSharedMemory(path, size, options = {}, token = systemToken) {
+  const shm = new SharedMemory(size);
+  objectManager.registerObject(path, shm, options);
+  return objectManager.openHandle(path, ['read', 'write'], token);
+}
+
+export function openSharedMemory(path, rights = ['read', 'write'], token = systemToken) {
+  return objectManager.openHandle(path, rights, token);
+}
+
+export function writeSharedMemory(handle, offset, data) {
+  const shm = objectManager.getObject(handle, ['write']);
+  shm.write(offset, data);
+}
+
+export function readSharedMemory(handle, offset, length) {
+  const shm = objectManager.getObject(handle, ['read']);
+  return shm.read(offset, length);
+}

--- a/system/services/kernel32.js
+++ b/system/services/kernel32.js
@@ -1,4 +1,8 @@
 import { KERNEL32_SERVICES } from '../../usermode/win32/kernel32.js';
+import { createNamedPipe } from '../../kernel/ipc/namedPipe.js';
+import { connectLpcPort as kernelConnectLpcPort } from '../../kernel/ipc/lpc.js';
+import { createMailslot as kernelCreateMailslot } from '../../kernel/ipc/mailslot.js';
+import { createSharedMemory as kernelCreateSharedMemory } from '../../kernel/ipc/sharedMemory.js';
 
 let schedulerRef;
 
@@ -25,6 +29,22 @@ export function writeConsole(handle, message) {
   return message.length;
 }
 
+export function createPipe(name, options) {
+  return createNamedPipe(name, options);
+}
+
+export function connectLpcPort(name) {
+  return kernelConnectLpcPort(name);
+}
+
+export function createMailslot(name, options) {
+  return kernelCreateMailslot(name, options);
+}
+
+export function createSharedMemory(name, size, options) {
+  return kernelCreateSharedMemory(name, size, options);
+}
+
 export function registerKernel32(syscall, scheduler) {
   schedulerRef = scheduler;
   syscall.registerService(KERNEL32_SERVICES.CREATE_PROCESS, createProcess);
@@ -32,4 +52,8 @@ export function registerKernel32(syscall, scheduler) {
   syscall.registerService(KERNEL32_SERVICES.SLEEP, sleep);
   syscall.registerService(KERNEL32_SERVICES.ALLOC_CONSOLE, allocConsole);
   syscall.registerService(KERNEL32_SERVICES.WRITE_CONSOLE, writeConsole);
+  syscall.registerService(KERNEL32_SERVICES.CREATE_PIPE, createPipe);
+  syscall.registerService(KERNEL32_SERVICES.CONNECT_LPC_PORT, connectLpcPort);
+  syscall.registerService(KERNEL32_SERVICES.CREATE_MAILSLOT, createMailslot);
+  syscall.registerService(KERNEL32_SERVICES.CREATE_SHARED_MEMORY, createSharedMemory);
 }

--- a/usermode/win32/kernel32.js
+++ b/usermode/win32/kernel32.js
@@ -5,7 +5,11 @@ export const KERNEL32_SERVICES = {
   EXIT_PROCESS: 0x1001,
   SLEEP: 0x1002,
   ALLOC_CONSOLE: 0x1003,
-  WRITE_CONSOLE: 0x1004
+  WRITE_CONSOLE: 0x1004,
+  CREATE_PIPE: 0x1100,
+  CONNECT_LPC_PORT: 0x1101,
+  CREATE_MAILSLOT: 0x1102,
+  CREATE_SHARED_MEMORY: 0x1103
 };
 
 // Basic console handle for userland apps. In a real system this would
@@ -35,4 +39,20 @@ export function WriteConsole(handle, message) {
     console.log(message);
   }
   return syscall.invoke(KERNEL32_SERVICES.WRITE_CONSOLE, handle, message);
+}
+
+export function CreatePipe(name, options) {
+  return syscall.invoke(KERNEL32_SERVICES.CREATE_PIPE, name, options);
+}
+
+export function ConnectLpcPort(name) {
+  return syscall.invoke(KERNEL32_SERVICES.CONNECT_LPC_PORT, name);
+}
+
+export function CreateMailslot(name, options) {
+  return syscall.invoke(KERNEL32_SERVICES.CREATE_MAILSLOT, name, options);
+}
+
+export function CreateSharedMemory(name, size, options) {
+  return syscall.invoke(KERNEL32_SERVICES.CREATE_SHARED_MEMORY, name, size, options);
 }


### PR DESCRIPTION
## Summary
- add IPC primitives (LPC ports, named pipes, mailslots, shared memory)
- expose CreatePipe, ConnectLpcPort, and related APIs through kernel32
- hook up kernel services with access control via objectManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893320025ec8329acb2b99eb4162b9f