### PR TITLE
feat(kernel): add PE loader and driver stack

### DIFF
--- a/kernel/io/driverStack.js
+++ b/kernel/io/driverStack.js
@@ -1,0 +1,32 @@
+/**
+ * Represents a stack of layered drivers. IRPs traverse the stack
+ * from the top driver down to the lowest driver.
+ */
+export class DriverStack {
+  constructor(drivers = []) {
+    this.drivers = drivers;
+  }
+
+  addDriver(driver) {
+    this.drivers.push(driver);
+  }
+
+  /**
+    * Send an IRP through the stack. Each driver receives the IRP and a
+    * callback to invoke the next driver in the chain.
+    * @param {IRP} irp
+    */
+  send(irp) {
+    let index = 0;
+    const next = () => {
+      const driver = this.drivers[index++];
+      if (driver && typeof driver.handleIrp === 'function') {
+        return driver.handleIrp(irp, next);
+      }
+      return irp.status;
+    };
+    return next();
+  }
+}
+
+export default DriverStack;

--- a/kernel/io/drivers/base.js
+++ b/kernel/io/drivers/base.js
@@ -1,12 +1,25 @@
 export class Driver {
-  constructor(name, irq) {
+  constructor(name, irq, version = '0.0.0') {
     this.name = name;
     this.irq = irq;
+    this.version = version;
   }
+
+  // Driver entry point
+  DriverEntry() {}
+
+  // Cleanup routine invoked on unload
+  DriverUnload() {}
 
   // Handle a generic request for the device
   handleRequest(_request) {
     // To be implemented by subclasses
+  }
+
+  // Handle an I/O Request Packet in a stack
+  handleIrp(_irp, next) {
+    if (typeof next === 'function') return next();
+    return 0;
   }
 
   // Handle an interrupt request

--- a/kernel/io/index.js
+++ b/kernel/io/index.js
@@ -7,4 +7,5 @@ import {
 } from '../../src/lib/hal/index.js';
 
 export { readPort, writePort, interruptController, timer, powerManagement };
-
+export { DriverStack } from './driverStack.js';
+export { IRP } from './irp.js';

--- a/kernel/io/irp.js
+++ b/kernel/io/irp.js
@@ -1,0 +1,16 @@
+export class IRP {
+  /**
+   * @param {Object} options
+   * @param {string} options.major Major function code
+   * @param {string} [options.minor] Minor function code
+   * @param {any} [options.data] Request payload
+   */
+  constructor({ major, minor = undefined, data = undefined } = {}) {
+    this.majorFunction = major;
+    this.minorFunction = minor;
+    this.data = data;
+    this.status = 0;
+  }
+}
+
+export default IRP;

--- a/kernel/loader/index.js
+++ b/kernel/loader/index.js
@@ -1,0 +1,79 @@
+export class Loader {
+  constructor() {
+    this.modules = new Map();
+  }
+
+  /**
+   * Parse minimal PE/COFF headers from an ArrayBuffer.
+   * Validates DOS and PE signatures and extracts the entry point.
+   * @param {ArrayBuffer} buffer
+   * @returns {Object} Parsed header info
+   */
+  parse(buffer) {
+    const view = new DataView(buffer);
+    // Check DOS header 'MZ'
+    if (view.getUint16(0, false) !== 0x4d5a) {
+      throw new Error('Invalid DOS signature');
+    }
+    const peOffset = view.getUint32(0x3c, true);
+    if (view.getUint32(peOffset, false) !== 0x50450000) {
+      throw new Error('Invalid PE signature');
+    }
+    const machine = view.getUint16(peOffset + 4, true);
+    const numberOfSections = view.getUint16(peOffset + 6, true);
+    const optionalHeaderSize = view.getUint16(peOffset + 20, true);
+    const optOffset = peOffset + 24;
+    const entryPoint = view.getUint32(optOffset + 16, true);
+    return { machine, numberOfSections, optionalHeaderSize, entryPoint };
+  }
+
+  /**
+   * Load a PE module and invoke its entry point.
+   * @param {string} name Module name
+   * @param {ArrayBuffer} buffer Binary contents
+   * @param {Object} [options] Additional options
+   * @param {function} [options.entry] Driver entry routine
+   * @param {function} [options.unload] Cleanup routine
+   * @param {string} [options.version] Module version string
+   * @returns {Object} Loaded module metadata
+   */
+  load(name, buffer, options = {}) {
+    const headers = this.parse(buffer);
+    const module = {
+      name,
+      headers,
+      version: options.version || '0.0.0',
+      entry: options.entry,
+      unload: options.unload
+    };
+    if (typeof module.entry === 'function') {
+      module.entry(module);
+    }
+    this.modules.set(name, module);
+    return module;
+  }
+
+  /**
+   * Unload a module and invoke its cleanup routine.
+   * @param {string} name Module name
+   */
+  unload(name) {
+    const module = this.modules.get(name);
+    if (!module) return;
+    if (typeof module.unload === 'function') {
+      module.unload(module);
+    }
+    this.modules.delete(name);
+  }
+
+  /**
+   * Retrieve loaded module metadata.
+   * @param {string} name Module name
+   */
+  get(name) {
+    return this.modules.get(name);
+  }
+}
+
+export const loader = new Loader();
+export default loader;

--- a/test/driverStack.test.js
+++ b/test/driverStack.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { DriverStack, IRP } from '../kernel/io/index.js';
+import Driver from '../kernel/io/drivers/base.js';
+
+test('IRPs traverse driver stacks', () => {
+  const stack = new DriverStack();
+  const calls = [];
+  class Upper extends Driver {
+    handleIrp(irp, next) {
+      calls.push('upper');
+      irp.data.push('upper');
+      return next();
+    }
+  }
+  class Lower extends Driver {
+    handleIrp(irp) {
+      calls.push('lower');
+      irp.data.push('lower');
+      irp.status = 42;
+      return irp.status;
+    }
+  }
+  stack.addDriver(new Upper('upper'));
+  stack.addDriver(new Lower('lower'));
+  const irp = new IRP({ major: 'read', data: [] });
+  const status = stack.send(irp);
+  assert.deepStrictEqual(calls, ['upper', 'lower']);
+  assert.deepStrictEqual(irp.data, ['upper', 'lower']);
+  assert.strictEqual(status, 42);
+});

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import loader from '../kernel/loader/index.js';
+
+function createMinimalPE() {
+  const buffer = new ArrayBuffer(256);
+  const view = new DataView(buffer);
+  view.setUint16(0, 0x4d5a, false); // 'MZ'
+  view.setUint32(0x3c, 0x80, true); // e_lfanew
+  view.setUint32(0x80, 0x50450000, false); // 'PE\0\0'
+  view.setUint16(0x84, 0x014c, true); // machine
+  view.setUint16(0x86, 0, true); // number of sections
+  view.setUint16(0x94, 0xe0, true); // optional header size
+  const opt = 0x80 + 24;
+  view.setUint32(opt + 16, 0x1000, true); // AddressOfEntryPoint
+  return buffer;
+}
+
+test('loader parses PE modules and handles entry/unload', () => {
+  const buffer = createMinimalPE();
+  let entryCalled = false;
+  let unloadCalled = false;
+  loader.load('test', buffer, {
+    version: '1.2.3',
+    entry: mod => {
+      entryCalled = true;
+      assert.strictEqual(mod.version, '1.2.3');
+    },
+    unload: () => {
+      unloadCalled = true;
+    }
+  });
+  const mod = loader.get('test');
+  assert.ok(mod);
+  assert.strictEqual(mod.headers.entryPoint, 0x1000);
+  assert.ok(entryCalled);
+  loader.unload('test');
+  assert.ok(unloadCalled);
+  assert.strictEqual(loader.get('test'), undefined);
+});


### PR DESCRIPTION
## Summary
- add PE/COFF loader supporting runtime load/unload
- implement IRP and driver stack for layered drivers
- expose driver entry/unload APIs with versioning

## Testing
- `node --experimental-json-modules --test test/loader.test.js test/driverStack.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6893387c6e288329add25bd060a7314d