### PR TITLE
feat: add registry tree and persistence

### DIFF
--- a/system/registry.js
+++ b/system/registry.js
@@ -1,33 +1,176 @@
-export class Registry {
+import { EventEmitter } from 'events';
+import fs from 'fs';
+
+class RegistryNode {
+  constructor(name, parent = null, value = null) {
+    this.name = name;
+    this.parent = parent;
+    this.value = value;
+    this.children = new Map();
+    this.acl = new Map(); // user => { read: bool, write: bool }
+  }
+}
+
+export class Registry extends EventEmitter {
   constructor() {
-    this.store = new Map();
+    super();
+    this.root = new RegistryNode('root');
+    // by default allow everyone
+    this.root.acl.set('*', { read: true, write: true });
   }
 
-  create(key, value) {
-    if (this.store.has(key)) {
+  _parsePath(path) {
+    if (!path) return [];
+    return path.split('/').filter(Boolean);
+  }
+
+  _getNode(path) {
+    const parts = this._parsePath(path);
+    let node = this.root;
+    for (const part of parts) {
+      node = node.children.get(part);
+      if (!node) return null;
+    }
+    return node;
+  }
+
+  _checkPermission(node, user, action) {
+    let current = node;
+    while (current) {
+      if (current.acl.has(user)) {
+        return !!current.acl.get(user)[action];
+      }
+      if (current.acl.has('*')) {
+        return !!current.acl.get('*')[action];
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  create(key, value, { user = '*', acl } = {}) {
+    const parts = this._parsePath(key);
+    let node = this.root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      let child = node.children.get(part);
+      if (!child) {
+        if (!this._checkPermission(node, user, 'write')) {
+          throw new Error('Access denied');
+        }
+        child = new RegistryNode(part, node);
+        node.children.set(part, child);
+      }
+      node = child;
+    }
+    const last = parts[parts.length - 1];
+    if (node.children.has(last)) {
       throw new Error('Key already exists');
     }
-    this.store.set(key, value);
+    if (!this._checkPermission(node, user, 'write')) {
+      throw new Error('Access denied');
+    }
+    const newNode = new RegistryNode(last, node, value);
+    if (acl) {
+      for (const [usr, perm] of Object.entries(acl)) {
+        newNode.acl.set(usr, perm);
+      }
+    }
+    node.children.set(last, newNode);
+    this.emit('create', key, value);
   }
 
-  read(key) {
-    return this.store.get(key);
+  read(key, user = '*') {
+    const node = this._getNode(key);
+    if (!node) return undefined;
+    if (!this._checkPermission(node, user, 'read')) {
+      throw new Error('Access denied');
+    }
+    return node.value;
   }
 
-  update(key, value) {
-    if (!this.store.has(key)) {
+  update(key, value, user = '*') {
+    const node = this._getNode(key);
+    if (!node) {
       throw new Error('Key not found');
     }
-    this.store.set(key, value);
+    if (!this._checkPermission(node, user, 'write')) {
+      throw new Error('Access denied');
+    }
+    node.value = value;
+    this.emit('update', key, value);
   }
 
-  delete(key) {
-    this.store.delete(key);
+  delete(key, user = '*') {
+    const parts = this._parsePath(key);
+    const last = parts.pop();
+    const parentPath = parts.join('/');
+    const parent = parts.length ? this._getNode(parentPath) : this.root;
+    if (!parent || !parent.children.has(last)) {
+      return;
+    }
+    const node = parent.children.get(last);
+    if (!this._checkPermission(node, user, 'write')) {
+      throw new Error('Access denied');
+    }
+    parent.children.delete(last);
+    this.emit('delete', key);
   }
 
-  keys() {
-    return Array.from(this.store.keys());
+  keys(path = '') {
+    const node = path ? this._getNode(path) : this.root;
+    if (!node) return [];
+    return Array.from(node.children.keys());
+  }
+
+  setACL(key, acl, user = '*') {
+    const node = this._getNode(key);
+    if (!node) {
+      throw new Error('Key not found');
+    }
+    if (!this._checkPermission(node, user, 'write')) {
+      throw new Error('Access denied');
+    }
+    node.acl.clear();
+    for (const [usr, perm] of Object.entries(acl)) {
+      node.acl.set(usr, perm);
+    }
+  }
+
+  saveToFile(file) {
+    const obj = this._nodeToObject(this.root);
+    fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+  }
+
+  loadFromFile(file) {
+    const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    this.root = this._objectToNode('root', data, null);
+  }
+
+  _nodeToObject(node) {
+    const children = {};
+    for (const [name, child] of node.children.entries()) {
+      children[name] = this._nodeToObject(child);
+    }
+    const acl = {};
+    for (const [user, perm] of node.acl.entries()) {
+      acl[user] = perm;
+    }
+    return { value: node.value, acl, children };
+  }
+
+  _objectToNode(name, obj, parent) {
+    const node = new RegistryNode(name, parent, obj.value);
+    for (const [user, perm] of Object.entries(obj.acl || {})) {
+      node.acl.set(user, perm);
+    }
+    for (const [childName, childObj] of Object.entries(obj.children || {})) {
+      const childNode = this._objectToNode(childName, childObj, node);
+      node.children.set(childName, childNode);
+    }
+    return node;
   }
 }
 
 export const registry = new Registry();
+

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
+import fs from 'fs';
 import { Registry } from '../system/registry.js';
 
 test('registry provides CRUD operations', () => {
@@ -10,4 +11,40 @@ test('registry provides CRUD operations', () => {
   assert.strictEqual(reg.read('foo'), 'baz');
   reg.delete('foo');
   assert.strictEqual(reg.read('foo'), undefined);
+});
+
+test('registry supports hierarchical keys and persistence', () => {
+  const reg = new Registry();
+  reg.create('foo/bar', 'baz');
+  assert.strictEqual(reg.read('foo/bar'), 'baz');
+
+  const tmp = './hive.json';
+  reg.saveToFile(tmp);
+
+  const reg2 = new Registry();
+  reg2.loadFromFile(tmp);
+  assert.strictEqual(reg2.read('foo/bar'), 'baz');
+
+  fs.unlinkSync(tmp);
+});
+
+test('registry enforces ACL and emits notifications', () => {
+  const reg = new Registry();
+  reg.create('secret', 'shh');
+  reg.setACL('secret', {
+    alice: { read: true, write: true },
+    bob: { read: false, write: false },
+  });
+
+  assert.strictEqual(reg.read('secret', 'alice'), 'shh');
+  assert.throws(() => reg.read('secret', 'bob'), /Access denied/);
+
+  let notified = false;
+  reg.on('update', (k, v) => {
+    if (k === 'secret' && v === 'open') notified = true;
+  });
+
+  reg.update('secret', 'open', 'alice');
+  assert.strictEqual(notified, true);
+  assert.throws(() => reg.update('secret', 'fail', 'bob'), /Access denied/);
 });


### PR DESCRIPTION
## Summary
- overhaul registry to store keys as hierarchical nodes with ACL checks and change notifications
- serialize/deserialize registry hives for persistence
- cover registry tree, ACLs, and notifications with tests

## Testing
- `node --experimental-json-modules --test test/registry.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68933ce2a7c8832998b91af9ac17ff20