### PR TITLE
Add performance monitoring service and user APIs

### DIFF
--- a/kernel/bootstrap.js
+++ b/kernel/bootstrap.js
@@ -12,6 +12,7 @@ import { syscall } from '../system/syscall.js';
 import { registerKernel32 } from '../system/services/kernel32.js';
 import { registerUser32 } from '../system/services/user32.js';
 import { registerGdi32 } from '../system/services/gdi32.js';
+import { registerPerfMon } from '../system/services/perfmon.js';
 
 /**
  * Bootstraps the kernel and core subsystems.
@@ -73,6 +74,7 @@ export async function bootstrap(options = {}) {
   registerKernel32(syscall, scheduler);
   registerUser32(syscall);
   registerGdi32(syscall);
+  registerPerfMon(syscall);
 
   // Launch initial system services
   for (const { name, service } of services) {

--- a/system/perfmon.js
+++ b/system/perfmon.js
@@ -1,0 +1,50 @@
+import process from 'node:process';
+
+export class PerfMon {
+  constructor() {
+    this.samples = [];
+    this.timer = null;
+  }
+
+  getHighResolutionTime() {
+    return process.hrtime.bigint();
+  }
+
+  getCounters() {
+    const cpu = process.cpuUsage();
+    const memory = process.memoryUsage();
+    const usage = process.resourceUsage?.() ?? {};
+    const io = {
+      read: usage.fsRead ?? 0,
+      write: usage.fsWrite ?? 0
+    };
+    return {
+      timestamp: this.getHighResolutionTime(),
+      cpu,
+      memory,
+      io
+    };
+  }
+
+  startSampling(intervalMs = 1000) {
+    if (this.timer) return false;
+    this.samples = [];
+    this.timer = setInterval(() => {
+      this.samples.push(this.getCounters());
+    }, intervalMs);
+    return true;
+  }
+
+  stopSampling() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    const data = this.samples;
+    this.samples = [];
+    return data;
+  }
+}
+
+export const perfmon = new PerfMon();
+export default perfmon;

--- a/system/services/perfmon.js
+++ b/system/services/perfmon.js
@@ -1,0 +1,20 @@
+import { PERFMON_SERVICES } from '../../usermode/win32/perfmon.js';
+import { perfmon } from '../perfmon.js';
+
+export function getCounters() {
+  return perfmon.getCounters();
+}
+
+export function startSampling(interval) {
+  return perfmon.startSampling(interval);
+}
+
+export function stopSampling() {
+  return perfmon.stopSampling();
+}
+
+export function registerPerfMon(syscall) {
+  syscall.registerService(PERFMON_SERVICES.GET_COUNTERS, getCounters);
+  syscall.registerService(PERFMON_SERVICES.START_SAMPLING, startSampling);
+  syscall.registerService(PERFMON_SERVICES.STOP_SAMPLING, stopSampling);
+}

--- a/test/perfmon.test.js
+++ b/test/perfmon.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { syscall } from '../system/syscall.js';
+import { registerPerfMon } from '../system/services/perfmon.js';
+import * as perfmon from '../usermode/win32/perfmon.js';
+
+registerPerfMon(syscall);
+
+test('perfmon returns counters', () => {
+  const counters = perfmon.GetPerformanceCounters();
+  assert.ok(counters.cpu);
+  assert.ok(counters.memory);
+  assert.ok(counters.io);
+  assert.equal(typeof counters.timestamp, 'bigint');
+});
+
+test('perfmon sampling collects data', async () => {
+  perfmon.StartSampling(5);
+  await new Promise(r => setTimeout(r, 20));
+  const samples = perfmon.StopSampling();
+  assert.ok(samples.length > 0);
+  for (const sample of samples) {
+    assert.equal(typeof sample.timestamp, 'bigint');
+  }
+});

--- a/usermode/win32/perfmon.js
+++ b/usermode/win32/perfmon.js
@@ -1,0 +1,19 @@
+import { syscall } from '../../system/syscall.js';
+
+export const PERFMON_SERVICES = {
+  GET_COUNTERS: 0x4000,
+  START_SAMPLING: 0x4001,
+  STOP_SAMPLING: 0x4002
+};
+
+export function GetPerformanceCounters() {
+  return syscall.invoke(PERFMON_SERVICES.GET_COUNTERS);
+}
+
+export function StartSampling(intervalMs) {
+  return syscall.invoke(PERFMON_SERVICES.START_SAMPLING, intervalMs);
+}
+
+export function StopSampling() {
+  return syscall.invoke(PERFMON_SERVICES.STOP_SAMPLING);
+}


### PR DESCRIPTION
## Summary
- implement `system/perfmon.js` to capture CPU, memory, and I/O stats with high-resolution timestamps
- expose perfmon counters through new syscall services and usermode wrappers
- register perfmon service during kernel bootstrap and add tests for counter access and sampling

## Testing
- `node --experimental-json-modules --test test/perfmon.test.js`
- `npm test` *(incomplete: hung after executing existing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6893b71a0adc83299471d25f60f59e7b