### PR TITLE
Implement job and session management

### DIFF
--- a/kernel/jobs.js
+++ b/kernel/jobs.js
@@ -1,0 +1,82 @@
+export class Job {
+  constructor(id, parent = null, limits = {}) {
+    this.id = id;
+    this.parent = parent;
+    this.processes = new Set();
+    this.childJobs = new Set();
+    this.limits = {
+      maxProcesses: Infinity,
+      cpuTime: Infinity,
+      memory: Infinity,
+      ...limits
+    };
+    this.accounting = {
+      cpuTime: 0,
+      memory: 0
+    };
+  }
+
+  addProcess(proc) {
+    if (this.processes.size >= this.limits.maxProcesses) {
+      throw new Error('Process limit exceeded');
+    }
+    this.processes.add(proc);
+    proc.job = this;
+  }
+
+  removeProcess(proc) {
+    this.processes.delete(proc);
+  }
+
+  addJob(job) {
+    this.childJobs.add(job);
+  }
+
+  recordUsage({ cpuTime = 0, memory = 0 } = {}) {
+    this.accounting.cpuTime += cpuTime;
+    this.accounting.memory += memory;
+    if (this.accounting.cpuTime > this.limits.cpuTime ||
+        this.accounting.memory > this.limits.memory) {
+      this.terminate();
+    }
+  }
+
+  terminate() {
+    for (const proc of this.processes) {
+      proc.state = 'terminated';
+    }
+    for (const job of this.childJobs) {
+      job.terminate();
+    }
+    this.processes.clear();
+    this.childJobs.clear();
+  }
+}
+
+export class JobTable {
+  constructor() {
+    this.jobs = new Map();
+    this.nextId = 1;
+    this.rootJob = this.createJob(null);
+  }
+
+  createJob(parent = this.rootJob, limits = {}) {
+    const job = new Job(this.nextId++, parent, limits);
+    this.jobs.set(job.id, job);
+    if (parent) {
+      parent.addJob(job);
+    }
+    return job;
+  }
+
+  getJob(id) {
+    return this.jobs.get(id);
+  }
+
+  terminateJob(id) {
+    const job = this.jobs.get(id);
+    if (job) {
+      job.terminate();
+    }
+  }
+}

--- a/kernel/scheduler.js
+++ b/kernel/scheduler.js
@@ -14,9 +14,9 @@ export class Scheduler {
     this.cpuContext = { registers: {}, sp: 0 };
   }
 
-  createProcess(priority = 0, token = systemToken) {
+  createProcess(priority = 0, token = systemToken, job = null, session = null) {
     try {
-      const proc = this.table.createProcess(priority, token);
+      const proc = this.table.createProcess(priority, token, job, session);
       this.enqueue(proc);
       return proc;
     } catch (err) {

--- a/kernel/session.js
+++ b/kernel/session.js
@@ -1,0 +1,58 @@
+export class Session {
+  constructor(id, token) {
+    this.id = id;
+    this.token = token;
+    this.processes = new Set();
+    this.jobs = new Set();
+    this.desktop = { id: `desktop-${id}`, windows: [] };
+  }
+
+  addProcess(proc) {
+    this.processes.add(proc);
+    proc.session = this;
+  }
+
+  removeProcess(proc) {
+    this.processes.delete(proc);
+  }
+
+  addJob(job) {
+    this.jobs.add(job);
+  }
+
+  terminate() {
+    for (const job of this.jobs) {
+      job.terminate();
+    }
+    for (const proc of this.processes) {
+      proc.state = 'terminated';
+    }
+    this.jobs.clear();
+    this.processes.clear();
+  }
+}
+
+export class SessionManager {
+  constructor() {
+    this.sessions = new Map();
+    this.nextId = 1;
+  }
+
+  createSession(token) {
+    const session = new Session(this.nextId++, token);
+    this.sessions.set(session.id, session);
+    return session;
+  }
+
+  getSession(id) {
+    return this.sessions.get(id);
+  }
+
+  terminateSession(id) {
+    const session = this.sessions.get(id);
+    if (session) {
+      session.terminate();
+      this.sessions.delete(id);
+    }
+  }
+}

--- a/test/jobsSessions.test.js
+++ b/test/jobsSessions.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JobTable } from '../kernel/jobs.js';
+import { SessionManager } from '../kernel/session.js';
+import { Scheduler } from '../kernel/scheduler.js';
+import { systemToken } from '../kernel/executive/security.js';
+
+function createScheduler() {
+  return new Scheduler();
+}
+
+test('job limits and termination', () => {
+  const jobs = new JobTable();
+  const sched = createScheduler();
+  const job = jobs.createJob(null, { maxProcesses: 2 });
+  const p1 = sched.createProcess(0, systemToken, job);
+  const p2 = sched.createProcess(0, systemToken, job);
+  assert.equal(job.processes.size, 2);
+  assert.throws(() => sched.createProcess(0, systemToken, job));
+  job.terminate();
+  assert.equal(p1.state, 'terminated');
+  assert.equal(p2.state, 'terminated');
+});
+
+test('session termination kills processes', () => {
+  const sched = createScheduler();
+  const jobs = new JobTable();
+  const sessions = new SessionManager();
+  const session = sessions.createSession(systemToken);
+  const job = jobs.createJob();
+  session.addJob(job);
+  const p = sched.createProcess(0, systemToken, job, session);
+  assert.ok(session.processes.has(p));
+  sessions.terminateSession(session.id);
+  assert.equal(p.state, 'terminated');
+});


### PR DESCRIPTION
## Summary
- add kernel job system for process limits and usage accounting
- add session manager to coordinate logon sessions and desktops
- track jobs and sessions for each process and expose through scheduler

## Testing
- `node --test test/jobsSessions.test.js`
- `npm test` *(fails: Command did not complete within 100s)*

------
https://chatgpt.com/codex/tasks/task_b_6893ce0ad0308329ac0623a0f1c4c345