### PR TITLE
feat: add boot loader

### DIFF
--- a/boot/loader.js
+++ b/boot/loader.js
@@ -1,0 +1,112 @@
+import bootstrap from '../kernel/bootstrap.js';
+
+/**
+ * BootLoader reads configuration from a filesystem, resolves module
+ * dependencies and initializes the kernel via bootstrap().
+ */
+export class BootLoader {
+  /**
+   * @param {Object} fs Mounted filesystem implementing readFile()
+   */
+  constructor(fs) {
+    if (!fs || typeof fs.readFile !== 'function') {
+      throw new Error('BootLoader requires a filesystem with readFile()');
+    }
+    this.fs = fs;
+  }
+
+  /**
+   * Initialize the system using the boot configuration.
+   *
+   * @param {string} [configPath] Path to boot configuration file
+   * @param {Object} [options]
+   * @param {boolean} [options.safeMode] Load only modules marked safe
+   * @returns {Promise<Object>} Result from kernel bootstrap
+   */
+  async load(configPath = '/boot/boot.json', options = {}) {
+    const { safeMode = false } = options;
+    let config;
+    try {
+      const raw = this.fs.readFile(configPath).toString() || '{}';
+      config = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`Failed to read boot configuration: ${e.message}`);
+    }
+    return this._bootWithConfig(config, { safeMode });
+  }
+
+  async _bootWithConfig(config, { safeMode = false, recovery = false } = {}) {
+    const moduleDefs = this._selectModules(config, safeMode);
+    try {
+      const kernelModules = await loadModules(this.fs, moduleDefs);
+      return await bootstrap({ kernelModules });
+    } catch (err) {
+      if (config.recovery && !recovery) {
+        const recSafe = safeMode || !!config.recovery.safeMode;
+        return this._bootWithConfig(config.recovery, {
+          safeMode: recSafe,
+          recovery: true
+        });
+      }
+      throw err;
+    }
+  }
+
+  _selectModules(config, safeMode) {
+    let mods = Array.isArray(config.modules) ? [...config.modules] : [];
+    if (safeMode) {
+      mods = mods.filter(m => m.safe !== false);
+    }
+    return mods;
+  }
+}
+
+function resolveDependencies(modules) {
+  const map = new Map();
+  for (const m of modules) map.set(m.name, m);
+  const visited = new Set();
+  const temp = new Set();
+  const order = [];
+  function visit(name) {
+    if (visited.has(name)) return;
+    if (temp.has(name)) throw new Error(`Circular dependency: ${name}`);
+    const mod = map.get(name);
+    if (!mod) throw new Error(`Missing module: ${name}`);
+    temp.add(name);
+    for (const dep of mod.deps || []) visit(dep);
+    temp.delete(name);
+    visited.add(name);
+    order.push(mod);
+  }
+  for (const m of modules) visit(m.name);
+  return order;
+}
+
+async function loadModules(fs, moduleDefs) {
+  const ordered = resolveDependencies(moduleDefs);
+  const loaded = [];
+  for (const info of ordered) {
+    const src = fs.readFile(info.path).toString();
+    const url = 'data:text/javascript;base64,' + Buffer.from(src).toString('base64');
+    const mod = await import(url);
+    loaded.push({ name: info.name, module: mod.default ?? mod });
+  }
+  return loaded;
+}
+
+/**
+ * Convenience function to create and run the BootLoader.
+ *
+ * @param {Object} options Loader options
+ * @param {Object} options.fs Filesystem instance
+ * @param {string} [options.configPath] Path to configuration file
+ * @param {boolean} [options.safeMode] Safe mode flag
+ * @returns {Promise<Object>} Result from kernel bootstrap
+ */
+export async function load(options = {}) {
+  const { fs, configPath, safeMode } = options;
+  const loader = new BootLoader(fs);
+  return loader.load(configPath, { safeMode });
+}
+
+export default load;

--- a/test/bootLoader.test.js
+++ b/test/bootLoader.test.js
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { NTFSFileSystem } from '../kernel/executive/fs/ntfs.js';
+import { load as bootLoad } from '../boot/loader.js';
+
+async function setupFS(files) {
+  const fs = new NTFSFileSystem();
+  fs.mount();
+  fs.mkdir('/boot');
+  for (const [path, content] of Object.entries(files)) {
+    const parts = path.split('/').slice(1, -1);
+    let current = '';
+    for (const part of parts) {
+      current += '/' + part;
+      try { fs.mkdir(current); } catch {}
+    }
+    fs.writeFile(path, content);
+  }
+  return fs;
+}
+
+test('boot loader loads modules with dependencies', async () => {
+  const fs = await setupFS({
+    '/boot/boot.json': JSON.stringify({
+      modules: [
+        { name: 'base', path: '/base.js' },
+        { name: 'extra', path: '/extra.js', deps: ['base'] }
+      ]
+    }),
+    '/base.js': 'export default { name: "base" };',
+    '/extra.js': 'export default { name: "extra" };'
+  });
+  const kernel = await bootLoad({ fs });
+  assert.ok(kernel.modules.has('base'));
+  assert.ok(kernel.modules.has('extra'));
+  kernel.scheduler.stop();
+});
+
+test('boot loader safe mode only loads safe modules', async () => {
+  const fs = await setupFS({
+    '/boot/boot.json': JSON.stringify({
+      modules: [
+        { name: 'core', path: '/core.js', safe: true },
+        { name: 'unsafe', path: '/unsafe.js', safe: false }
+      ]
+    }),
+    '/core.js': 'export default { name: "core" };',
+    '/unsafe.js': 'export default { name: "unsafe" };'
+  });
+  const kernel = await bootLoad({ fs, safeMode: true });
+  assert.ok(kernel.modules.has('core'));
+  assert.ok(!kernel.modules.has('unsafe'));
+  kernel.scheduler.stop();
+});
+
+test('boot loader uses recovery modules on failure', async () => {
+  const fs = await setupFS({
+    '/boot/boot.json': JSON.stringify({
+      modules: [ { name: 'missing', path: '/missing.js' } ],
+      recovery: { modules: [ { name: 'recover', path: '/recover.js' } ] }
+    }),
+    '/recover.js': 'export default { name: "recover" };'
+  });
+  const kernel = await bootLoad({ fs });
+  assert.ok(kernel.modules.has('recover'));
+  kernel.scheduler.stop();
+});


### PR DESCRIPTION
## Summary
- implement boot loader that reads configuration, resolves dependencies, and bootstraps kernel modules
- add tests for normal, safe mode, and recovery boot paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68942908db3c83299a5b751e3254e86f