### PR TITLE
feat: add service dependency and restart management

### DIFF
--- a/kernel/bootstrap.js
+++ b/kernel/bootstrap.js
@@ -77,8 +77,8 @@ export async function bootstrap(options = {}) {
   registerPerfMon(syscall);
 
   // Launch initial system services
-  for (const { name, service } of services) {
-    serviceManager.register(name, service);
+  for (const { name, service, deps, restart } of services) {
+    serviceManager.register(name, service, { deps, restart });
   }
   for (const { name } of services) {
     await serviceManager.start(name);

--- a/system/serviceManager.js
+++ b/system/serviceManager.js
@@ -3,20 +3,65 @@ export class ServiceManager {
     this.services = new Map();
   }
 
-  register(name, service) {
-    this.services.set(name, { service, running: false });
+  register(name, service, options = {}) {
+    const {
+      deps = [],
+      restart = 'never'
+    } = options;
+    this.services.set(name, {
+      service,
+      deps,
+      restart,
+      running: false,
+      instance: null,
+      handle: null,
+      args: [],
+      stopping: false
+    });
   }
 
   async start(name, ...args) {
+    return this.#startInternal(name, new Set(), ...args);
+  }
+
+  async #startInternal(name, visited, ...args) {
+    if (visited.has(name)) {
+      throw new Error(`Circular dependency detected: ${name}`);
+    }
+    visited.add(name);
+
     const entry = this.services.get(name);
     if (!entry) {
       throw new Error(`Unknown service: ${name}`);
     }
-    if (entry.running) return;
-    if (typeof entry.service.start === 'function') {
-      await entry.service.start(...args);
+
+    for (const dep of entry.deps) {
+      await this.#startInternal(dep, visited, ...args);
     }
-    entry.running = true;
+
+    if (entry.running) return;
+
+    entry.args = args;
+
+    try {
+      if (typeof entry.service.start === 'function') {
+        const result = entry.service.start(...args);
+        // Await resolution to capture rejections; supports sync and async starts
+        await Promise.resolve(result);
+        entry.instance = result;
+        this.#attachRestart(name, entry);
+      }
+      entry.running = true;
+    } catch (err) {
+      entry.running = false;
+      if (entry.restart === 'always' || entry.restart === 'on-failure') {
+        setTimeout(() => {
+          // best effort restart; swallow errors to avoid unhandled rejection
+          this.start(name, ...entry.args).catch(() => {});
+        }, 0);
+      }
+      throw err;
+    }
   }
 
   async stop(name, ...args) {
@@ -25,15 +70,50 @@ export class ServiceManager {
       throw new Error(`Unknown service: ${name}`);
     }
     if (!entry.running) return;
+    entry.stopping = true;
+    if (entry.instance && entry.handle && typeof entry.instance.off === 'function') {
+      for (const evt of ['exit', 'close', 'error']) {
+        entry.instance.off(evt, entry.handle);
+      }
+    }
     if (typeof entry.service.stop === 'function') {
       await entry.service.stop(...args);
     }
     entry.running = false;
+    entry.instance = null;
+    entry.handle = null;
+    entry.stopping = false;
   }
 
   isRunning(name) {
     const entry = this.services.get(name);
     return entry ? entry.running : false;
+  }
+
+  #attachRestart(name, entry) {
+    const source = entry.instance;
+    if (!source || typeof source.on !== 'function') return;
+
+    const handler = (err) => {
+      if (entry.handle && source.off) {
+        for (const evt of ['exit', 'close', 'error']) {
+          source.off(evt, entry.handle);
+        }
+      }
+      entry.running = false;
+      entry.instance = null;
+      if (entry.stopping) return;
+      if (entry.restart === 'always' || (entry.restart === 'on-failure' && err)) {
+        setTimeout(() => {
+          this.start(name, ...entry.args).catch(() => {});
+        }, 0);
+      }
+    };
+
+    entry.handle = handler;
+    for (const evt of ['exit', 'close', 'error']) {
+      source.on(evt, handler);
+    }
   }
 }
 

--- a/test/serviceManager.test.js
+++ b/test/serviceManager.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { ServiceManager } from '../system/serviceManager.js';
+import { EventEmitter } from 'node:events';
 
 test('service manager starts and stops services', async () => {
   const manager = new ServiceManager();
@@ -14,4 +15,59 @@ test('service manager starts and stops services', async () => {
   await manager.stop('demo');
   assert.deepStrictEqual(events, ['start', 'stop']);
   assert.strictEqual(manager.isRunning('demo'), false);
+});
+
+test('service manager starts dependencies in order', async () => {
+  const manager = new ServiceManager();
+  const events = [];
+  manager.register('c', { start: () => events.push('c') });
+  manager.register('b', { start: () => events.push('b') }, { deps: ['c'] });
+  manager.register('a', { start: () => events.push('a') }, { deps: ['b'] });
+  await manager.start('a');
+  assert.deepStrictEqual(events, ['c', 'b', 'a']);
+});
+
+test('service manager prevents dependency cycles', async () => {
+  const manager = new ServiceManager();
+  manager.register('x', { start() {} }, { deps: ['y'] });
+  manager.register('y', { start() {} }, { deps: ['x'] });
+  await assert.rejects(() => manager.start('x'), /Circular dependency/);
+});
+
+test('restarts on start failure with on-failure policy', async () => {
+  const manager = new ServiceManager();
+  let attempts = 0;
+  manager.register('svc', {
+    async start() {
+      attempts++;
+      if (attempts === 1) {
+        throw new Error('fail');
+      }
+    }
+  }, { restart: 'on-failure' });
+
+  await assert.rejects(manager.start('svc'));
+  await new Promise(r => setTimeout(r, 10));
+  assert.strictEqual(manager.isRunning('svc'), true);
+});
+
+test('restarts when service stops unexpectedly with always policy', async () => {
+  const manager = new ServiceManager();
+  let starts = 0;
+  class Svc extends EventEmitter {
+    start() {
+      starts++;
+      return this;
+    }
+    stop() {
+      this.emit('exit');
+    }
+  }
+  const svc = new Svc();
+  manager.register('svc', svc, { restart: 'always' });
+  await manager.start('svc');
+  assert.strictEqual(starts, 1);
+  svc.emit('exit');
+  await new Promise(r => setTimeout(r, 10));
+  assert.strictEqual(starts, 2);
 });


### PR DESCRIPTION
## Summary
- allow services to declare dependencies and restart policies
- recursively launch dependent services and detect cycles
- auto-restart services on failures or unexpected stops

## Testing
- `npm test`
- `node --test test/serviceManager.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68946ccc88d083298011e9e5b4fda14d