### PR TITLE
Add thread management syscalls

### DIFF
--- a/kernel/bootstrap.js
+++ b/kernel/bootstrap.js
@@ -1,7 +1,7 @@
 import { PhysicalMemory } from './memory/physicalMemory.js';
 import { VirtualMemory } from './memory/virtualMemory.js';
 import { Scheduler } from './scheduler.js';
-import { Thread } from './thread.js';
+import { Thread, registerThreadSyscalls } from './thread.js';
 import { deviceManager } from './io/deviceManager.js';
 import DisplayDriver from './io/drivers/display.js';
 import InputDriver from './io/drivers/input.js';
@@ -72,6 +72,7 @@ export async function bootstrap(options = {}) {
 
   // Register core system call services
   registerKernel32(syscall, scheduler);
+  registerThreadSyscalls(syscall, scheduler);
   registerUser32(syscall);
   registerGdi32(syscall);
   registerPerfMon(syscall);

--- a/kernel/thread.js
+++ b/kernel/thread.js
@@ -1,4 +1,8 @@
+import { THREAD_SYSCALLS } from '../system/syscall.js';
+
 let nextTid = 1;
+const threadTable = new Map();
+let schedulerRef;
 
 export class Thread {
   constructor(entry, scheduler = null) {
@@ -33,4 +37,71 @@ export class Thread {
     }
     return this.scheduler.blockThread(this, object, timeout, alertable);
   }
+}
+
+export function createThread(startRoutine, param, creationFlags = 0) {
+  const thread = new Thread(() => startRoutine(param), schedulerRef);
+  const proc = schedulerRef.current;
+  if (!proc) {
+    throw new Error('No current process');
+  }
+  proc.addThread(thread);
+  threadTable.set(thread.tid, { thread, process: proc });
+
+  if (!(creationFlags & 0x1)) {
+    Promise.resolve()
+      .then(() => thread.start())
+      .catch(err => console.error('Thread start error', err));
+  } else {
+    thread.state = 'suspended';
+  }
+  return thread.tid;
+}
+
+export function suspendThread(tid) {
+  const record = threadTable.get(tid);
+  if (!record) {
+    return -1;
+  }
+  if (record.thread.state === 'running' || record.thread.state === 'ready') {
+    record.thread.state = 'suspended';
+  }
+  return 0;
+}
+
+export function resumeThread(tid) {
+  const record = threadTable.get(tid);
+  if (!record) {
+    return -1;
+  }
+  if (record.thread.state === 'suspended') {
+    record.thread.state = 'ready';
+    Promise.resolve()
+      .then(() => record.thread.start())
+      .catch(err => console.error('Thread start error', err));
+  }
+  return 0;
+}
+
+export function exitThread(code = 0) {
+  const proc = schedulerRef.current;
+  if (!proc || proc.threads.length === 0) {
+    return code;
+  }
+  const thread = proc.threads[0];
+  thread.state = 'terminated';
+  threadTable.delete(thread.tid);
+  const idx = proc.threads.indexOf(thread);
+  if (idx !== -1) {
+    proc.threads.splice(idx, 1);
+  }
+  return code;
+}
+
+export function registerThreadSyscalls(syscall, scheduler) {
+  schedulerRef = scheduler;
+  syscall.registerService(THREAD_SYSCALLS.CREATE_THREAD, createThread);
+  syscall.registerService(THREAD_SYSCALLS.SUSPEND_THREAD, suspendThread);
+  syscall.registerService(THREAD_SYSCALLS.RESUME_THREAD, resumeThread);
+  syscall.registerService(THREAD_SYSCALLS.EXIT_THREAD, exitThread);
 }

--- a/system/syscall.js
+++ b/system/syscall.js
@@ -1,3 +1,10 @@
+export const THREAD_SYSCALLS = {
+  CREATE_THREAD: 0x1200,
+  SUSPEND_THREAD: 0x1201,
+  RESUME_THREAD: 0x1202,
+  EXIT_THREAD: 0x1203
+};
+
 export class SyscallDispatcher {
   constructor() {
     this.serviceTable = new Map();

--- a/usermode/win32/kernel32.js
+++ b/usermode/win32/kernel32.js
@@ -1,4 +1,4 @@
-import { syscall } from '../../system/syscall.js';
+import { syscall, THREAD_SYSCALLS } from '../../system/syscall.js';
 
 export const KERNEL32_SERVICES = {
   CREATE_PROCESS: 0x1000,
@@ -9,7 +9,11 @@ export const KERNEL32_SERVICES = {
   CREATE_PIPE: 0x1100,
   CONNECT_LPC_PORT: 0x1101,
   CREATE_MAILSLOT: 0x1102,
-  CREATE_SHARED_MEMORY: 0x1103
+  CREATE_SHARED_MEMORY: 0x1103,
+  CREATE_THREAD: THREAD_SYSCALLS.CREATE_THREAD,
+  SUSPEND_THREAD: THREAD_SYSCALLS.SUSPEND_THREAD,
+  RESUME_THREAD: THREAD_SYSCALLS.RESUME_THREAD,
+  EXIT_THREAD: THREAD_SYSCALLS.EXIT_THREAD
 };
 
 // Basic console handle for userland apps. In a real system this would
@@ -55,4 +59,36 @@ export function CreateMailslot(name, options) {
 
 export function CreateSharedMemory(name, size, options) {
   return syscall.invoke(KERNEL32_SERVICES.CREATE_SHARED_MEMORY, name, size, options);
+}
+
+export function CreateThread(
+  lpThreadAttributes,
+  dwStackSize,
+  lpStartAddress,
+  lpParameter,
+  dwCreationFlags = 0,
+  lpThreadId = null
+) {
+  const tid = syscall.invoke(
+    KERNEL32_SERVICES.CREATE_THREAD,
+    lpStartAddress,
+    lpParameter,
+    dwCreationFlags
+  );
+  if (lpThreadId) {
+    lpThreadId.value = tid;
+  }
+  return tid;
+}
+
+export function SuspendThread(thread) {
+  return syscall.invoke(KERNEL32_SERVICES.SUSPEND_THREAD, thread);
+}
+
+export function ResumeThread(thread) {
+  return syscall.invoke(KERNEL32_SERVICES.RESUME_THREAD, thread);
+}
+
+export function ExitThread(code = 0) {
+  return syscall.invoke(KERNEL32_SERVICES.EXIT_THREAD, code);
 }


### PR DESCRIPTION
## Summary
- add syscall numbers for thread management
- implement thread creation and state transitions with dispatcher registration
- expose Win32-style thread wrappers in kernel32

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68947c30982c832994c32bc5ceb2a420