### PR TITLE
Add basic audio driver and WinMM wrapper

### DIFF
--- a/kernel/bootstrap.js
+++ b/kernel/bootstrap.js
@@ -7,6 +7,7 @@ import DisplayDriver from './io/drivers/display.js';
 import InputDriver from './io/drivers/input.js';
 import NetworkDriver from './io/drivers/network.js';
 import StorageDriver from './io/drivers/storage.js';
+import { registerWinmm } from '../system/services/winmm.js';
 import { serviceManager } from '../system/serviceManager.js';
 import { syscall } from '../system/syscall.js';
 import { registerKernel32 } from '../system/services/kernel32.js';
@@ -76,6 +77,7 @@ export async function bootstrap(options = {}) {
   registerUser32(syscall);
   registerGdi32(syscall);
   registerPerfMon(syscall);
+  registerWinmm(syscall);
 
   // Launch initial system services
   for (const { name, service, deps, restart } of services) {

--- a/kernel/io/deviceManager.js
+++ b/kernel/io/deviceManager.js
@@ -2,6 +2,7 @@ import { interruptController, powerManagement } from '../../src/lib/hal/index.js
 import pnpManager from '../pnp/index.js';
 import { logError } from '../../system/eventLog.js';
 import { createCrashDump } from '../../system/crashDump.js';
+import AudioDriver from './drivers/audio.js';
 
 export class DeviceManager {
   constructor() {
@@ -92,4 +93,5 @@ export class DeviceManager {
 }
 
 export const deviceManager = new DeviceManager();
+deviceManager.registerDriver(new AudioDriver());
 export default deviceManager;

--- a/kernel/io/drivers/audio.js
+++ b/kernel/io/drivers/audio.js
@@ -1,0 +1,30 @@
+import Driver from './base.js';
+
+export class AudioDriver extends Driver {
+  constructor() {
+    super('audio', 'IRQ_AUDIO');
+    this.requests = [];
+  }
+
+  handleRequest(request) {
+    this.requests.push(request);
+    if (request?.type === 'tone') {
+      return this.playTone(request.freq, request.duration);
+    }
+    if (request?.type === 'buffer') {
+      return this.playBuffer(request.buffer);
+    }
+    // Unknown request type
+    return null;
+  }
+
+  playTone(freq, duration) {
+    return `audio:tone:${freq}:${duration}`;
+  }
+
+  playBuffer(buffer) {
+    return `audio:buffer:${buffer?.length ?? 0}`;
+  }
+}
+
+export default AudioDriver;

--- a/system/services/winmm.js
+++ b/system/services/winmm.js
@@ -1,0 +1,15 @@
+import { WINMM_SERVICES } from '../../usermode/win32/winmm.js';
+import deviceManager from '../../kernel/io/deviceManager.js';
+
+export function playTone(freq, duration) {
+  return deviceManager.sendRequest('audio', { type: 'tone', freq, duration });
+}
+
+export function playBuffer(buffer) {
+  return deviceManager.sendRequest('audio', { type: 'buffer', buffer });
+}
+
+export function registerWinmm(syscall) {
+  syscall.registerService(WINMM_SERVICES.PLAY_TONE, playTone);
+  syscall.registerService(WINMM_SERVICES.PLAY_BUFFER, playBuffer);
+}

--- a/test/audio.test.js
+++ b/test/audio.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import deviceManager from '../kernel/io/deviceManager.js';
+import AudioDriver from '../kernel/io/drivers/audio.js';
+import { PlayTone, PlayBuffer } from '../usermode/win32/winmm.js';
+import { registerWinmm } from '../system/services/winmm.js';
+import { syscall } from '../system/syscall.js';
+
+function setup() {
+  deviceManager.reset();
+  const audio = new AudioDriver();
+  deviceManager.registerDriver(audio);
+  registerWinmm(syscall);
+  return audio;
+}
+
+test('audio driver plays tone via winmm wrapper', () => {
+  const audio = setup();
+  assert.strictEqual(PlayTone(440, 1000), 'audio:tone:440:1000');
+  assert.deepStrictEqual(audio.requests[0], { type: 'tone', freq: 440, duration: 1000 });
+});
+
+test('audio driver plays buffer via winmm wrapper', () => {
+  const audio = setup();
+  const buffer = new Uint8Array([1, 2, 3]);
+  assert.strictEqual(PlayBuffer(buffer), 'audio:buffer:3');
+  assert.deepStrictEqual(audio.requests[0], { type: 'buffer', buffer });
+});

--- a/usermode/win32/winmm.js
+++ b/usermode/win32/winmm.js
@@ -1,0 +1,14 @@
+import { syscall } from '../../system/syscall.js';
+
+export const WINMM_SERVICES = {
+  PLAY_TONE: 0x3000,
+  PLAY_BUFFER: 0x3001
+};
+
+export function PlayTone(freq, duration) {
+  return syscall.invoke(WINMM_SERVICES.PLAY_TONE, freq, duration);
+}
+
+export function PlayBuffer(buffer) {
+  return syscall.invoke(WINMM_SERVICES.PLAY_BUFFER, buffer);
+}


### PR DESCRIPTION
## Summary
- implement AudioDriver with tone/buffer playback and IRQ mapping
- expose WinMM user-mode API and kernel service for audio requests
- register WinMM during kernel bootstrap and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6894811ad2988329aea02704410bb652