### PR TITLE
docs: add internal documentation and update links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to win32.run
 
-Thank you for considering a contribution to **win32.run**! The project is under active development, and we welcome bug reports, feature requests, documentation improvements, and pull requests.
+Thank you for considering a contribution to **win32.run**! The project is under active development, and we welcome bug reports, feature requests, documentation improvements, and pull requests. For an overview of the codebase, see the [docs](docs/README.md).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Windows XP in the browser, with a File System, programs, XP-style File Picker and Saver dialogs, 3rd-party program, etc.
 ## [🍭 win32.run](https://win32.run)
 
-**win32.run is actively developed.** We welcome issues, feature requests, and pull requests—see [CONTRIBUTING.md](CONTRIBUTING.md) to get involved.
+**win32.run is actively developed.** We welcome issues, feature requests, and pull requests—see [CONTRIBUTING.md](CONTRIBUTING.md) to get involved and browse the [docs](docs/README.md) for details about the project.
 
 ![License Unlicense](https://badgen.net/badge/license/Unlicense/green)
 [![css tailwind](https://badgen.net/badge/css/tailwind/blue)](https://github.com/tailwindlabs/tailwindcss)
@@ -85,9 +85,7 @@ Put the build output (`dist` and `.solid`), `package.json`, and `package-lock.js
 
 Finally, run `npm start` (or use a process manager like `pm2 start .solid/server/server.js`) to serve win32 at `localhost:3000`.
 # Documentation
-If you're interested in expanding or customizing win32.run, please have a look at its documentation. Contributions and suggestions for improving the docs are always welcome.
-
-[![Please visit docs.win32.run](https://img.shields.io/badge/view-Documentation-blue?style=for-the-badge)](https://docs.win32.run)
+If you're interested in expanding or customizing win32.run, take a look at the documentation stored in the [docs](docs/README.md) directory. Contributions and suggestions for improving the docs are always welcome.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# win32.run Documentation
+
+Welcome to the developer documentation for **win32.run**. This project is an in-browser recreation of Windows XP built with SolidJS and Tailwind CSS.
+
+## Getting Started
+- Install dependencies with `npm install`.
+- Start the development server with `npm run dev` (http://localhost:3000).
+- Build for production with `npm run build` and serve via `npm start`.
+
+## Project Architecture
+win32.run runs entirely in the browser. A minimal JavaScript kernel in [`src/lib/kernel.js`](../src/lib/kernel.js) lets programs register and launch at runtime and provides extension points for subsystems.
+
+## API
+For details on interacting with win32.run from third-party programs, see [api.md](api.md).
+
+## Contributing
+Feedback and pull requests are welcome! See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on how to get involved.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,43 @@
+# Win32 API
+
+This document describes the JavaScript interface available to third-party programs running inside win32.run.
+
+## pick_files
+Let users pick files through the win32.run file picker.
+
+**Parameters**
+- `desc`: description of the desired files.
+- `exts`: array of acceptable file extensions.
+- `multiple`: allow selecting multiple files (default: `true`).
+
+**Returns**
+- `Promise<Array<Object>>` resolving to an array of win32 file objects.
+
+## save_file
+Save content to an existing win32 file without showing the save dialog.
+
+**Parameters**
+- `file`: [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object.
+- `id`: win32 file identifier.
+
+**Returns**
+- `Promise<void>`
+
+## save_file_as
+Open the save dialog to create or overwrite a file on win32.run.
+
+**Parameters**
+- `file`: [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object.
+- `types`: array of `{ desc, mime, ext }` describing acceptable formats.
+
+**Returns**
+- `Promise<string>` resolving to the id of the saved file.
+
+## get_file
+Retrieve a file by its identifier.
+
+**Parameters**
+- `id`: win32 file identifier.
+
+**Returns**
+- `Promise<Object>` resolving to a win32 file object.

--- a/static/js/api/0.js
+++ b/static/js/api/0.js
@@ -39,7 +39,7 @@ class Win32 {
      * ```
      * Specify an empty array [] to accept any extension
      * @param {boolean} multiple Whether to accept multiple or single file. Default to true.
-     * @returns {Promise<[Object]>} an array of win32 files. See {@link https://docs.win32.run/3rd-party-apps/pick-files#returns Docs}
+     * @returns {Promise<[Object]>} an array of win32 files. See docs/api.md#pick_files for details.
      */
     async pick_files(desc = '', exts = [], multiple = true) {
         console.log(this.parent_origin)
@@ -98,7 +98,7 @@ class Win32 {
      *  {desc: 'Bitmap', mime: 'image/bmp', ext: '.bmp'},
      * ]
      * ```
-     * See {@link https://docs.win32.run Docs} for more details.
+     * See docs/api.md for more details.
      * @returns {Promise<String>} id of the saved file, which later can be used to retrieve said file info with this.get_file(id)
      */
     async save_file_as(file, types) {
@@ -124,7 +124,7 @@ class Win32 {
     /**
      * @description Get a file on win32.run by its id.
      * @param {String} id id of the file
-     * @returns {Promise<Object>} a win32 file object. See {@link https://docs.win32.run/3rd-party-apps/pick-files#returns Docs}
+     * @returns {Promise<Object>} a win32 file object. See docs/api.md#pick_files for details.
      */
     async get_file(id) {
         this.send({


### PR DESCRIPTION
## Summary
- add developer documentation in new `docs/` directory
- update README and CONTRIBUTING to reference in-repo docs
- replace external documentation links and update API comments

## Testing
- `node --experimental-json-modules --test test/*.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689484e9e744832987d87e3ade6000f5