### PR TITLE
Fix file size computation in new_fs_item_raw

### DIFF
--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -305,7 +305,7 @@ export async function new_fs_item_raw(item, parent_id){
     if(item.file != null){
         item.url = short.generate();
         await idb.set(item.url, item.file);
-        item.size = Math.ceil(file.size/1024);
+        item.size = Math.ceil(item.file.size / 1024);
         delete item.file;
     } else if(item.executable){
         item.url = './programs/webapp.jsx';


### PR DESCRIPTION
## Summary
- correctly compute size using `item.file` in `new_fs_item_raw`

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68954c6d87288329b61596748dfe5127