### PR TITLE
Fix click_outside CustomEvent detail

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -55,7 +55,7 @@ export function click_outside(node) {
         
 
         node.dispatchEvent(
-          new CustomEvent('click_outside', node)
+          new CustomEvent('click_outside', { detail: node })
         )
       }
     }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { includes } from '../src/lib/utils.js';
+import { JSDOM } from 'jsdom';
+import { includes, click_outside } from '../src/lib/utils.js';
 
 test('includes handles primitive values', () => {
   assert.strictEqual(includes(2, [1, 2, 3]), true);
@@ -13,4 +14,31 @@ test('includes works with objects without equals method', () => {
   const arr = [obj];
   assert.strictEqual(includes(obj, arr), true);
   assert.strictEqual(includes({ a: 1 }, arr), false);
+});
+
+test('click_outside dispatches node in event.detail', () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="node"></div><div id="outside"></div>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.CustomEvent = dom.window.CustomEvent;
+
+  const node = document.getElementById('node');
+  const outside = document.getElementById('outside');
+
+  const action = click_outside(node);
+
+  let received = null;
+  node.addEventListener('click_outside', (event) => {
+    received = event.detail;
+  });
+
+  outside.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+  assert.strictEqual(received, node);
+
+  action.destroy();
+
+  delete global.window;
+  delete global.document;
+  delete global.CustomEvent;
 });


### PR DESCRIPTION
## Summary
- fix click_outside action to pass target node via CustomEvent.detail
- add unit test confirming event.detail contains the node

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68954c725bb08329877ceccf2e99c41c