### PR TITLE
Refactor compile_params to encode search params and add tests

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,15 +1,15 @@
 import mime_db from './mime.json' with { type: 'json' };
 
 export function compile_params(new_params){
-    
+
     const urlSearchParams = new URLSearchParams(window.location.search);
-    let params = Object.fromEntries(urlSearchParams.entries());
-    for(let key of Object.keys(new_params)){
-        params[key] = new_params[key];
-    }
-    return params = Object.keys(params)
+    const params = {
+        ...Object.fromEntries(urlSearchParams.entries()),
+        ...new_params
+    };
+    return Object.keys(params)
     .filter(key => params[key] != null)
-    .map(key => `${key}=${params[key]}`)
+    .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
     .join('&').trim();
 }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
-import { includes, click_outside } from '../src/lib/utils.js';
+import { includes, click_outside, compile_params } from '../src/lib/utils.js';
 
 test('includes handles primitive values', () => {
   assert.strictEqual(includes(2, [1, 2, 3]), true);
@@ -41,4 +41,15 @@ test('click_outside dispatches node in event.detail', () => {
   delete global.window;
   delete global.document;
   delete global.CustomEvent;
+});
+
+test('compile_params merges params and encodes special characters', () => {
+  const dom = new JSDOM('', { url: 'https://example.com/?q=hello%20world' });
+  global.window = dom.window;
+
+  const result = compile_params({ 'a b': 'c&d' });
+
+  assert.strictEqual(result, 'q=hello%20world&a%20b=c%26d');
+
+  delete global.window;
 });


### PR DESCRIPTION
## Summary
- refactor compile_params to merge existing URL params with object spread and encode keys/values
- add unit test for compile_params covering spaces and special characters

## Testing
- `npx eslint src/lib/utils.js test/utils.test.js`
- `node --experimental-json-modules --test test/utils.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689597e587b08329802b4d2add5e02c6